### PR TITLE
Replaces the 40mm GL among the Prime Decanus loadouts with a Rock-It Launcher and several High-Explosive nades.

### DIFF
--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -475,13 +475,14 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 
 /datum/outfit/loadout/decprimboom
 	name = "Loud Prime Decanus"
-	suit_store = /obj/item/gun/ballistic/revolver/grenadelauncher
+	suit_store = null
 	backpack_contents = list(
-		/obj/item/ammo_box/a40mm = 2,
+		/obj/item/grenade/syndieminibomb/concussion = 5,
 		/obj/item/gun/ballistic/revolver/m29 = 1,
 		/obj/item/ammo_box/m44 = 3,
 		/obj/item/grenade/f13/frag = 2,
 		/obj/item/grenade/homemade/coffeepotbomb = 1,
+		/obj/item/rockitlauncher_pack = 1,
 		)
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request
Did you know the Legion gets a free high-explosive 40mm GL and two boxes of HE ammo for it just for having a Prime Decanus on the map? Well, not anymore. They will now get a Rock-It Launcher and 5 HE Grenades instead. The launcher actually primes the grenades that come out of it, and you can load multiple at once.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Instead of one grenade that will instantly wipe anything it's pointed at off the face of the map like a mini-nuke with a shrapnel payload, you can instead fire one or more hand grenades at once, or any other explosive that is hand-primed and thrown that happens to fit in the launcher. Experiment!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
balance: Replaces the 40mm launcher and nades in the Loud Decanus loadout with a Rock-It Launcher and 5 HE hand grenades, which should hopefully be more balanced for PvP.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
