### PR TITLE
Fix Attempt to Punga Fruit

### DIFF
--- a/code/modules/hydroponics/grown/punga.dm
+++ b/code/modules/hydroponics/grown/punga.dm
@@ -18,7 +18,7 @@
 	icon_dead = "punga-dead"
 	icon_harvest = "punga-harvest"
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/repeated_harvest)
-	reagents_add = list(/datum/reagent/medicine/charcoal = 0.1, /datum/reagent/consumable/nutriment = 0.1, /datum/reagent/medicine/radaway = 0.05)
+	reagents_add = list(/datum/reagent/medicine/antitoxin = 0.05, /datum/reagent/consumable/nutriment = 0.1, /datum/reagent/medicine/radaway = 0.1)
 
 /obj/item/reagent_containers/food/snacks/grown/pungafruit
 	seed = /obj/item/seeds/punga


### PR DESCRIPTION
## About The Pull Request

Removes the charcoal from the Punga, replacing it with anti-toxin instead.

## Why It's Good For The Game

The charcoal turns the radaway in the punga fruit unusable, making it impossible get an actual benefit from the punga fruit aside of be cave fungus 2.0. I hope the anti-toxin doesn't the the same problem with the radaway.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
fix: Pungafruit should be actually purge radiation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
