### PR TITLE
Buffs Traumapack

### DIFF
--- a/code/modules/fallout/obj/items.dm
+++ b/code/modules/fallout/obj/items.dm
@@ -26,7 +26,7 @@
 		var/mob/living/carbon/M = loc
 		if(src == M.back)
 			if(M.health < M.maxHealth)
-				M.adjustBruteLoss(-2) //Heal that poor bastard
-				M.adjustFireLoss(-2)
-				M.adjustToxLoss(-2)
-				M.adjustOxyLoss(-2)
+				M.adjustBruteLoss(-5) //Heal that poor bastard
+				M.adjustFireLoss(-3)
+				M.adjustToxLoss(-2) 
+				M.adjustOxyLoss(-1) //Why do we need oxy healing?

--- a/code/modules/fallout/obj/items.dm
+++ b/code/modules/fallout/obj/items.dm
@@ -29,4 +29,4 @@
 				M.adjustBruteLoss(-5) //Heal that poor bastard
 				M.adjustFireLoss(-3)
 				M.adjustToxLoss(-2) 
-				M.adjustOxyLoss(-1) //Why do we need oxy healing?
+				M.adjustOxyLoss(-2) //Why do we need oxy healing?


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Slightly buffs traumapack so people can get healed a bit faster

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Traumapack is a very rare item, there is only one preset spawn in the entire game, and that is in the shop
To use the traumapack you need to sacrifice your entie backpack slot, and this only will leave your belt, armor and pockets storage

this heals way too slowly for a item that claims it heals the user, this PR plans to slightly buff the traumapack so it can heal brute damage a little faster and make worth of sacrificing your backpack slot

seriously this item is too underrated to be a legendary item


**IF you think this is "too much" of a buff, feel free to comment**

before: cant get out of soft crit under 20 seconds (-50% health)
after: can get out of softcrit in 14 (-50% health)



## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
tweak: buffed the traumapack
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
