### PR TITLE
id card to identification

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -402,11 +402,11 @@
 
 /obj/item/card/id/proc/update_label(newname, newjob)
 	if(newname || newjob)
-		name = "[(!newname)	? "identification card"	: "[newname]'s ID Card"][(!newjob) ? "" : " ([newjob])"]"
+		name = "[(!newname)	? "identification card"	: "[newname]'s idenitfication"][(!newjob) ? "" : " ([newjob])"]"
 		update_icon()
 		return
 
-	name = "[(!registered_name)	? "identification card"	: "[registered_name]'s ID Card"][(!assignment) ? "" : " ([assignment])"]"
+	name = "[(!registered_name)	? "identification card"	: "[registered_name]'s idenitfication"][(!assignment) ? "" : " ([assignment])"]"
 	update_icon()
 
 /obj/item/card/id/silver


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request

webedit to change 'id card' to 'identification'

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
code: id card is now identification on examine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
