### PR TITLE
gauss amr and bozar yet again

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -2184,11 +2184,11 @@
 	icon_state = "blueprint_loot"
 	lootcount = 1
 	loot = list(
-// 		/obj/item/book/granter/crafting_recipe/blueprint/gauss,
-//		/obj/item/book/granter/crafting_recipe/blueprint/am_rifle,
+ 		/obj/item/book/granter/crafting_recipe/blueprint/gauss,
+		/obj/item/book/granter/crafting_recipe/blueprint/am_rifle,
 		/obj/item/book/granter/crafting_recipe/blueprint/citykiller,
 		/obj/item/book/granter/crafting_recipe/blueprint/rangemaster,
-//		/obj/item/book/granter/crafting_recipe/blueprint/bozar
+		/obj/item/book/granter/crafting_recipe/blueprint/bozar
 	)
 
 /obj/effect/spawner/lootdrop/f13/blueprintVHighPartsWeighted


### PR DESCRIPTION


## About The Pull Request

Uncomments the Gauss, AMR and Bozar blueprints from the lootdrops.

## Why It's Good For The Game

fun

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.



## Changelog

:cl:
tweak: amr, gauss and bozar blueprints can now spawn as loot again
/:cl:

