### PR TITLE
[DNM] Brotherhood of Steel Bunker Remap

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -520,7 +520,7 @@
 "acU" = (
 /obj/item/circuitboard/machine/ore_redemption,
 /obj/structure/frame/machine,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "aei" = (
 /obj/machinery/door/window/left/directional/north,
@@ -1119,7 +1119,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/obj/machinery/conveyor_switch/oneway{
+	id = "QMUnload"
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "aAk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1452,14 +1455,7 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "aQB" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "QMLoad"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/pod/light,
 /area/f13/brotherhood)
 "aRp" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1761,10 +1757,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"blY" = (
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/brotherhood)
 "bma" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -2167,11 +2159,10 @@
 	dir = 1;
 	id = "QMLoad"
 	},
-/obj/structure/fence/handrail{
-	dir = 4;
-	pixel_x = -15
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "bCG" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -7926,7 +7917,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "ebV" = (
 /obj/item/storage/box/lights/tubes,
@@ -8003,7 +7997,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "egP" = (
 /obj/structure/billboard/cola/pristine,
@@ -8371,7 +8365,7 @@
 "eBa" = (
 /obj/effect/turf_decal/box,
 /obj/structure/cable,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "eBc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8889,7 +8883,7 @@
 /area/f13/brotherhood)
 "flq" = (
 /obj/machinery/mineral/wasteland_vendor,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "fml" = (
 /obj/structure/chair/bench{
@@ -9801,7 +9795,7 @@
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "gxc" = (
 /obj/structure/simple_door/bunker{
@@ -10194,10 +10188,13 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "gXg" = (
+/obj/machinery/computer/cargo{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "gXR" = (
 /obj/structure/table{
@@ -11017,20 +11014,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/f13/brotherhood)
-"hUK" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "QMLoad"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/fence/handrail{
-	dir = 4;
-	pixel_x = -15
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/brotherhood)
 "hUY" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -11431,7 +11414,7 @@
 	},
 /area/f13/followers)
 "iqA" = (
-/turf/open/floor/plasteel/elevatorshaft,
+/turf/open/floor/pod/dark,
 /area/f13/brotherhood)
 "irs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11751,15 +11734,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "iLK" = (
-/obj/machinery/conveyor/inverted,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/fence/handrail{
-	dir = 4;
-	pixel_x = -15
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "QMUnload"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "iLR" = (
 /obj/structure/sink{
@@ -12774,7 +12756,7 @@
 /obj/effect/turf_decal/caution{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "jWy" = (
 /obj/structure/decoration/warning,
@@ -13033,12 +13015,6 @@
 	name = "reactor cooling pool"
 	},
 /area/f13/building/massfusion)
-"krl" = (
-/obj/effect/turf_decal/caution{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/brotherhood)
 "krv" = (
 /obj/machinery/vending/wardrobe/engi_wardrobe,
 /obj/effect/decal/cleanable/dirt,
@@ -13528,7 +13504,7 @@
 	dir = 4
 	},
 /obj/machinery/mineral/wasteland_vendor/weapons/BoS,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "laf" = (
 /obj/effect/turf_decal/stripes/red/line{
@@ -14823,7 +14799,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "msk" = (
 /obj/machinery/door/airlock/hatch{
@@ -15379,13 +15355,7 @@
 "nfe" = (
 /obj/effect/turf_decal/box,
 /obj/structure/closet/crate,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/brotherhood)
-"nfk" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "nho" = (
 /obj/effect/decal/cleanable/dirt,
@@ -15459,7 +15429,7 @@
 "nnk" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/recycler,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "nnA" = (
 /obj/machinery/door/airlock/medical{
@@ -16156,10 +16126,15 @@
 	},
 /area/f13/bunker)
 "omy" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 5;
+	height = 7;
+	id = "supply_home";
+	name = "Cargo Bay";
+	width = 12
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/turf/open/floor/pod/light,
 /area/f13/brotherhood)
 "omE" = (
 /obj/structure/ore_box,
@@ -16697,7 +16672,7 @@
 /obj/machinery/status_display/supply{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "oOp" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17241,7 +17216,7 @@
 /obj/structure/closet/crate/wooden,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "pvC" = (
 /obj/structure/table/reinforced,
@@ -17330,7 +17305,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "pAE" = (
 /obj/item/multitool,
@@ -17344,18 +17319,14 @@
 /turf/open/floor/plating,
 /area/f13/building/museum)
 "pAW" = (
-/obj/machinery/conveyor{
-	dir = 5;
-	id = "QMLoad2"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/fence/handrail{
-	dir = 4;
-	pixel_x = -15
+/obj/machinery/conveyor{
+	dir = 5;
+	id = "QMUnload"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "pBq" = (
 /obj/machinery/sleeper{
@@ -18055,21 +18026,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"qmH" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "QMLoad"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/camera/autoname{
-	dir = 10;
-	name = "North Facing Camera";
-	network = list("BoS")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/brotherhood)
 "qnu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -18275,20 +18231,6 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/carpet/black,
-/area/f13/brotherhood)
-"qyY" = (
-/obj/machinery/conveyor{
-	dir = 9;
-	id = "garbage"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/fence/handrail{
-	dir = 4;
-	pixel_x = -15
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood)
 "qzp" = (
 /obj/effect/turf_decal/stripes/white/line{
@@ -18550,9 +18492,6 @@
 "qMG" = (
 /obj/structure/simple_door/metal/fence,
 /turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood)
-"qNe" = (
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/brotherhood)
 "qNj" = (
 /obj/item/twohanded/required/kirbyplants/random,
@@ -19874,15 +19813,8 @@
 	},
 /area/f13/building/massfusion)
 "svq" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "QMLoad"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/closet/crate/science,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "svy" = (
 /obj/effect/decal/cleanable/generic,
@@ -20301,16 +20233,16 @@
 	},
 /area/f13/tunnel)
 "sQF" = (
-/obj/machinery/conveyor/inverted{
-	dir = 8;
-	id = "garbage"
-	},
 /obj/machinery/light{
 	dir = 1;
 	light_color = "#706891"
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "QMUnload"
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "sRk" = (
 /obj/structure/rack,
@@ -21446,15 +21378,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "umJ" = (
-/obj/machinery/conveyor/inverted{
-	dir = 10;
-	id = "garbage"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/machinery/conveyor/inverted{
+	dir = 10;
+	id = "QMUnload"
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "unv" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1{
@@ -22242,7 +22174,7 @@
 "vqM" = (
 /obj/effect/turf_decal/box,
 /obj/effect/spawner/lootdrop/crate_spawner,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "vsR" = (
 /obj/machinery/light/small{
@@ -22876,12 +22808,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"weG" = (
-/obj/structure/closet/crate/wooden,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/brotherhood)
 "weO" = (
 /obj/structure/sign/poster/contraband/pinup_topless{
 	pixel_x = 32
@@ -23455,8 +23381,11 @@
 	},
 /area/f13/brotherhood)
 "wNJ" = (
-/obj/machinery/conveyor/inverted,
-/turf/open/indestructible/ground/outside/desert,
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/closed/wall/r_wall/f13/vault,
 /area/f13/brotherhood)
 "wNV" = (
 /obj/structure/rack/shelf_metal,
@@ -24127,12 +24056,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/f13/building/museum)
-"xMh" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/brotherhood)
 "xMo" = (
 /obj/structure/fence/handrail{
 	density = 0;
@@ -24192,15 +24115,16 @@
 	},
 /area/f13/brotherhood)
 "xPK" = (
-/obj/machinery/conveyor{
-	dir = 8;
+/obj/effect/turf_decal/caution{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/conveyor_switch/oneway{
 	id = "QMLoad"
 	},
-/obj/machinery/light,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "xPV" = (
 /obj/structure/table/reinforced,
@@ -72963,7 +72887,7 @@ ryF
 ryF
 ryF
 ryF
-ryF
+oVq
 oVq
 oVq
 oVq
@@ -73220,20 +73144,20 @@ ryF
 ryF
 ryF
 ryF
-ryF
 oVq
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
+uQM
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
 oVq
 icO
 fFB
@@ -73477,8 +73401,8 @@ ryF
 ryF
 ryF
 ryF
-ryF
 oVq
+uQM
 iqA
 iqA
 iqA
@@ -73734,20 +73658,20 @@ ryF
 ryF
 lBb
 ryF
-ryF
 oVq
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
+uQM
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
 oVq
 sXj
 ajc
@@ -73991,20 +73915,20 @@ ryF
 lBb
 lBb
 ryF
-ryF
 oVq
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
+uQM
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
 oVq
 saZ
 ajc
@@ -74248,20 +74172,20 @@ lBb
 lBb
 lBb
 ryF
-ryF
 oVq
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
+uQM
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
 oVq
 tWa
 ajc
@@ -74505,8 +74429,8 @@ ryF
 lBb
 ryF
 ryF
-ryF
 oVq
+uQM
 iqA
 iqA
 iqA
@@ -74762,20 +74686,20 @@ ryF
 ryF
 ryF
 ryF
-ryF
 oVq
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
+uQM
+aQB
+aQB
+aQB
+aQB
+aQB
+aQB
+omy
+aQB
+aQB
+aQB
+aQB
+aQB
 oVq
 wwI
 ajc
@@ -75019,10 +74943,10 @@ ryF
 ryF
 ryF
 ryF
-ryF
+oVq
 oVq
 pAW
-wNJ
+iLK
 iLK
 umJ
 gwL
@@ -75030,8 +74954,8 @@ gXg
 gwL
 ebG
 bCy
-hUK
-qyY
+bCy
+bCy
 oVq
 oVq
 onW
@@ -75276,21 +75200,21 @@ lBb
 ryF
 ryF
 ryF
-ryF
+oVq
 oVq
 sQF
 aAb
-aAb
 pAo
-krl
+pAo
 jWs
-krl
+jWs
+jWs
 pAo
-aAb
+pAo
 pAo
 xPK
+wNJ
 oVq
-wwI
 onW
 onW
 onW
@@ -75533,18 +75457,18 @@ lBb
 ryF
 ryF
 ryF
-ryF
+oVq
 oVq
 pYk
-qNe
-qZg
+onW
+onW
 pvA
-weG
-qNe
-blY
-weG
-qZg
-qNe
+pvA
+onW
+svq
+pvA
+onW
+onW
 svq
 oVq
 onW
@@ -75790,19 +75714,19 @@ ryF
 ryF
 ryF
 ryF
-ryF
+oVq
 oVq
 equ
-qNe
-qNe
-blY
+onW
+onW
+svq
 nfe
-qZg
+onW
 nnk
-weG
-qNe
-qZg
-qmH
+pvA
+onW
+onW
+svq
 oVq
 onW
 qQK
@@ -76047,19 +75971,19 @@ ryF
 ryF
 ryF
 ryF
-ryF
+oVq
 oVq
 pmx
-qNe
-qZg
+onW
+onW
 acU
-qZg
-qZg
-qZg
-qZg
-qZg
-qNe
-aQB
+onW
+onW
+onW
+onW
+onW
+onW
+svq
 oVq
 onW
 ljv
@@ -76304,18 +76228,18 @@ ryF
 ryF
 ryF
 ryF
-ryF
+oVq
 oVq
 eQw
-qZg
-qNe
-qZg
-omy
-nfk
-xMh
-nfk
-xMh
-nfk
+onW
+onW
+onW
+hbN
+wSs
+wSs
+wSs
+wSs
+wSs
 eBa
 oVq
 onW
@@ -76561,18 +76485,18 @@ ryF
 ryF
 ryF
 ryF
-ryF
+oVq
 oVq
 oVq
 oNP
 flq
 kZu
 egw
-qNe
-qZg
-qNe
+onW
+onW
+onW
 msi
-qNe
+onW
 vqM
 oVq
 onW

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -517,11 +517,14 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+<<<<<<< Updated upstream
 "acU" = (
 /obj/item/circuitboard/machine/ore_redemption,
 /obj/structure/frame/machine,
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
+=======
+>>>>>>> Stashed changes
 "aei" = (
 /obj/machinery/door/window/left/directional/north,
 /obj/machinery/shower{
@@ -1118,6 +1121,7 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+<<<<<<< Updated upstream
 	},
 /obj/machinery/conveyor_switch/oneway{
 	id = "QMUnload"
@@ -1127,6 +1131,17 @@
 "aAk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+=======
+	},
+/obj/machinery/conveyor_switch/oneway{
+	id = "QMUnload"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
+"aAk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+>>>>>>> Stashed changes
 /obj/machinery/camera/autoname{
 	dir = 10;
 	name = "North Facing Camera";
@@ -1322,12 +1337,21 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
+<<<<<<< Updated upstream
 	},
 /area/f13/brotherhood)
 "aJI" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
+=======
+	},
+/area/f13/brotherhood)
+"aJI" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+>>>>>>> Stashed changes
 /obj/item/stack/sheet/prewar/five,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
@@ -1455,6 +1479,7 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "aQB" = (
+<<<<<<< Updated upstream
 /turf/open/floor/pod/light,
 /area/f13/brotherhood)
 "aRp" = (
@@ -1469,6 +1494,26 @@
 	layer = 3
 	},
 /obj/structure/window/reinforced{
+=======
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/closed/wall/r_wall/f13/vault,
+/area/f13/brotherhood)
+"aRp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/obj/structure/window/reinforced{
+>>>>>>> Stashed changes
 	color = "#3e3d42"
 	},
 /obj/structure/flora/ausbushes/fullgrass,
@@ -1757,6 +1802,13 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+<<<<<<< Updated upstream
+=======
+"blY" = (
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
+>>>>>>> Stashed changes
 "bma" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -10968,6 +11020,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
 	icon_state = "tealwhrusty_chess2"
+<<<<<<< Updated upstream
 	},
 /area/f13/brotherhood)
 "hRv" = (
@@ -10978,6 +11031,18 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+=======
+	},
+/area/f13/brotherhood)
+"hRv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+>>>>>>> Stashed changes
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood)
 "hSI" = (
@@ -11014,6 +11079,20 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/f13/brotherhood)
+<<<<<<< Updated upstream
+=======
+"hUK" = (
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 5;
+	height = 7;
+	id = "supply_home";
+	name = "Cargo Bay";
+	width = 12
+	},
+/turf/open/floor/pod/light,
+/area/f13/brotherhood)
+>>>>>>> Stashed changes
 "hUY" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -11133,6 +11212,7 @@
 /obj/structure/flora/junglebush/b,
 /obj/structure/flora/ausbushes/ppflowers{
 	pixel_x = -6
+<<<<<<< Updated upstream
 	},
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/window/reinforced{
@@ -11144,6 +11224,19 @@
 	dir = 1;
 	layer = 3
 	},
+=======
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+>>>>>>> Stashed changes
 /turf/open/water,
 /area/f13/brotherhood)
 "idJ" = (
@@ -11414,7 +11507,11 @@
 	},
 /area/f13/followers)
 "iqA" = (
+<<<<<<< Updated upstream
 /turf/open/floor/pod/dark,
+=======
+/turf/open/floor/pod/light,
+>>>>>>> Stashed changes
 /area/f13/brotherhood)
 "irs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16126,6 +16223,7 @@
 	},
 /area/f13/bunker)
 "omy" = (
+<<<<<<< Updated upstream
 /obj/docking_port/stationary{
 	dir = 8;
 	dwidth = 5;
@@ -16135,6 +16233,9 @@
 	width = 12
 	},
 /turf/open/floor/pod/light,
+=======
+/turf/open/floor/pod/dark,
+>>>>>>> Stashed changes
 /area/f13/brotherhood)
 "omE" = (
 /obj/structure/ore_box,
@@ -16596,10 +16697,17 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "4-8"
+<<<<<<< Updated upstream
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
+=======
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+>>>>>>> Stashed changes
 /area/f13/brotherhood)
 "oJK" = (
 /obj/structure/railing{
@@ -18985,11 +19093,19 @@
 /obj/structure/curtain{
 	color = "#5c131b";
 	pixel_y = -32
+<<<<<<< Updated upstream
 	},
 /obj/item/kirbyplants/photosynthetic,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "casino"
 	},
+=======
+	},
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+>>>>>>> Stashed changes
 /area/f13/brotherhood)
 "rAu" = (
 /obj/machinery/autolathe,
@@ -19786,6 +19902,7 @@
 	},
 /obj/structure/chair/bench{
 	pixel_y = 15
+<<<<<<< Updated upstream
 	},
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood)
@@ -19794,6 +19911,16 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+=======
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
+"stH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+>>>>>>> Stashed changes
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "stX" = (
@@ -22229,10 +22356,17 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+<<<<<<< Updated upstream
 	},
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
 	},
+=======
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+>>>>>>> Stashed changes
 /area/f13/brotherhood)
 "vwJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23378,6 +23512,7 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
+<<<<<<< Updated upstream
 	},
 /area/f13/brotherhood)
 "wNJ" = (
@@ -23386,6 +23521,9 @@
 	dir = 1
 	},
 /turf/closed/wall/r_wall/f13/vault,
+=======
+	},
+>>>>>>> Stashed changes
 /area/f13/brotherhood)
 "wNV" = (
 /obj/structure/rack/shelf_metal,
@@ -24482,8 +24620,13 @@
 	},
 /area/f13/brotherhood)
 "yfD" = (
+<<<<<<< Updated upstream
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+=======
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+>>>>>>> Stashed changes
 /turf/open/floor/plasteel/darkpurple,
 /area/f13/brotherhood)
 "yfV" = (
@@ -73146,6 +73289,7 @@ ryF
 ryF
 oVq
 uQM
+<<<<<<< Updated upstream
 aQB
 aQB
 aQB
@@ -73158,6 +73302,20 @@ aQB
 aQB
 aQB
 aQB
+=======
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+>>>>>>> Stashed changes
 oVq
 icO
 fFB
@@ -73403,6 +73561,7 @@ ryF
 ryF
 oVq
 uQM
+<<<<<<< Updated upstream
 iqA
 iqA
 iqA
@@ -73415,6 +73574,20 @@ iqA
 iqA
 iqA
 iqA
+=======
+omy
+omy
+omy
+omy
+omy
+omy
+omy
+omy
+omy
+omy
+omy
+omy
+>>>>>>> Stashed changes
 oVq
 cTh
 onW
@@ -73660,6 +73833,7 @@ lBb
 ryF
 oVq
 uQM
+<<<<<<< Updated upstream
 aQB
 aQB
 aQB
@@ -73672,6 +73846,20 @@ aQB
 aQB
 aQB
 aQB
+=======
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+>>>>>>> Stashed changes
 oVq
 sXj
 ajc
@@ -73917,6 +74105,7 @@ lBb
 ryF
 oVq
 uQM
+<<<<<<< Updated upstream
 aQB
 aQB
 aQB
@@ -73929,6 +74118,20 @@ aQB
 aQB
 aQB
 aQB
+=======
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+>>>>>>> Stashed changes
 oVq
 saZ
 ajc
@@ -74174,6 +74377,7 @@ lBb
 ryF
 oVq
 uQM
+<<<<<<< Updated upstream
 aQB
 aQB
 aQB
@@ -74186,6 +74390,20 @@ aQB
 aQB
 aQB
 aQB
+=======
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+>>>>>>> Stashed changes
 oVq
 tWa
 ajc
@@ -74431,6 +74649,7 @@ ryF
 ryF
 oVq
 uQM
+<<<<<<< Updated upstream
 iqA
 iqA
 iqA
@@ -74443,6 +74662,20 @@ iqA
 iqA
 iqA
 iqA
+=======
+omy
+omy
+omy
+omy
+omy
+omy
+omy
+omy
+omy
+omy
+omy
+omy
+>>>>>>> Stashed changes
 oVq
 bhS
 ajc
@@ -74688,6 +74921,7 @@ ryF
 ryF
 oVq
 uQM
+<<<<<<< Updated upstream
 aQB
 aQB
 aQB
@@ -74700,6 +74934,20 @@ aQB
 aQB
 aQB
 aQB
+=======
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+hUK
+iqA
+iqA
+iqA
+iqA
+iqA
+>>>>>>> Stashed changes
 oVq
 wwI
 ajc
@@ -75213,7 +75461,11 @@ pAo
 pAo
 pAo
 xPK
+<<<<<<< Updated upstream
 wNJ
+=======
+aQB
+>>>>>>> Stashed changes
 oVq
 onW
 onW
@@ -75465,11 +75717,19 @@ onW
 pvA
 pvA
 onW
+<<<<<<< Updated upstream
 svq
 pvA
 onW
 onW
 svq
+=======
+blY
+pvA
+onW
+onW
+blY
+>>>>>>> Stashed changes
 oVq
 onW
 onW
@@ -75719,14 +75979,22 @@ oVq
 equ
 onW
 onW
+<<<<<<< Updated upstream
 svq
+=======
+blY
+>>>>>>> Stashed changes
 nfe
 onW
 nnk
 pvA
 onW
 onW
+<<<<<<< Updated upstream
 svq
+=======
+blY
+>>>>>>> Stashed changes
 oVq
 onW
 qQK
@@ -75976,14 +76244,22 @@ oVq
 pmx
 onW
 onW
+<<<<<<< Updated upstream
 acU
+=======
+>>>>>>> Stashed changes
 onW
 onW
 onW
 onW
 onW
 onW
+<<<<<<< Updated upstream
 svq
+=======
+onW
+blY
+>>>>>>> Stashed changes
 oVq
 onW
 ljv
@@ -87267,12 +87543,20 @@ aak
 aak
 aae
 aae
+<<<<<<< Updated upstream
+=======
+aae
+aae
+>>>>>>> Stashed changes
 aae
 aae
 aae
 aae
+<<<<<<< Updated upstream
 aae
 aae
+=======
+>>>>>>> Stashed changes
 ryF
 jUU
 jUU

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -187,6 +187,16 @@
 "aaN" = (
 /turf/closed/wall/rust,
 /area/f13/tunnel/southwestbighorn)
+"aaO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor{
+	desc = "A wall built to withstand an atomic explosion.";
+	icon = 'icons/fallout/turfs/walls/vault_reinforced.dmi';
+	icon_state = "vaultrwall0";
+	icon_type_smooth = "vaultrwall";
+	name = "vault reinforced wall"
+	},
+/area/f13/brotherhood)
 "aaP" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
@@ -507,20 +517,40 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"aew" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
+"acU" = (
+/obj/item/circuitboard/machine/ore_redemption,
+/obj/structure/frame/machine,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
+"aei" = (
+/obj/machinery/door/window/left/directional/north,
+/obj/machinery/shower{
+	dir = 1
 	},
-/obj/structure/urinal,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood)
+"aew" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "afn" = (
 /obj/structure/chair/stool,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel/bighorn)
+"afv" = (
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "afx" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel/f13,
@@ -541,14 +571,10 @@
 	},
 /area/f13/building/massfusion)
 "aiq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/brotherhood/leisure)
+/obj/structure/table/reinforced,
+/obj/machinery/rnd/destructive_analyzer,
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "ajc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
@@ -592,11 +618,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "aly" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/brotherhood/medical)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood)
 "alS" = (
 /obj/structure/guncase,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -747,11 +771,17 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "aoY" = (
-/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
-/turf/open/floor/plasteel/darkred/side,
-/area/f13/brotherhood/armory)
+/obj/item/toy/plush/nukeplushie{
+	desc = "A stuffed toy that resembles a Chinese spy/ The tag claims operatives to be purely fictitious and not stealing your armory.";
+	name = "Knight-Captain Aryom";
+	pixel_x = 9
+	},
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "apc" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood,
@@ -806,12 +836,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "aqo" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-12"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/structure/rack/shelf_metal,
+/obj/item/circuitboard/machine/pacman,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "aqv" = (
 /obj/structure/railing{
 	dir = 4
@@ -840,11 +868,120 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "aqQ" = (
-/obj/structure/chair/sofa/corp/left{
+/obj/structure/rack,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/shoes/combat/swat{
+	pixel_x = 7;
+	pixel_y = -9
+	},
+/obj/item/clothing/shoes/combat/swat{
+	pixel_x = 7;
+	pixel_y = -9
+	},
+/obj/item/clothing/shoes/combat/swat{
+	pixel_x = 7;
+	pixel_y = -9
+	},
+/obj/item/clothing/shoes/combat/swat{
+	pixel_x = 7;
+	pixel_y = -9
+	},
+/obj/item/clothing/shoes/combat/swat{
+	pixel_x = 7;
+	pixel_y = -9
+	},
+/obj/item/storage/belt/military{
+	pixel_x = -7;
+	pixel_y = -9
+	},
+/obj/item/storage/belt/military{
+	pixel_x = -7;
+	pixel_y = -9
+	},
+/obj/item/storage/belt/military{
+	pixel_x = -7;
+	pixel_y = -9
+	},
+/obj/item/storage/belt/military{
+	pixel_x = -7;
+	pixel_y = -9
+	},
+/obj/item/storage/belt/military{
+	pixel_x = -7;
+	pixel_y = -9
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 10
+	},
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 10
+	},
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 10
+	},
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 10
+	},
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 10
+	},
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 10
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_y = 11
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_y = 11
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_y = 11
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_y = 11
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
 	dir = 8
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "arj" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -867,19 +1004,25 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "avf" = (
-/obj/machinery/door/airlock/hatch{
-	id_tag = "knights1";
-	name = "Knight Quarters"
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/dorms)
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "avx" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "avL" = (
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/offices1st)
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
+"avY" = (
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood)
 "awh" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
@@ -893,55 +1036,111 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "axe" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/grille,
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/armory)
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/restraints/legcuffs,
+/obj/item/storage/box/handcuffs,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood)
+"axh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/workbench/forge{
+	desc = "A reactor-heated megafurnace used for forging metal items such as swords, spears and shields and more.";
+	icon_state = "generator_on";
+	name = "superheating forge"
+	},
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "axq" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
 "axw" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/timeddoor,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
+"ayy" = (
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/ausbushes/grassybush{
+	layer = 2.1
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/turf/open/water,
+/area/f13/brotherhood)
+"ayZ" = (
+/obj/structure/chair/office/dark,
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "azk" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/museum)
 "azL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/bed,
-/obj/item/bedsheet/rd{
-	desc = "A fine quilted blanket, made with purple and yellow fabric.";
-	dream_messages = list("authority","a silvery ID","a bomb","a mech","a facehugger","maniacal laughter");
-	name = "fine bedsheet"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/landmark/start/f13/headscribe,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/structure/fence/handrail{
+	density = 0;
+	layer = 4.1;
+	pixel_y = -14
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "bcircuit1";
+	light_color = "#0076bc";
+	light_power = 3;
+	light_range = 4
+	},
+/area/f13/brotherhood)
 "aAb" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor{
-	req_access_txt = "255"
+/obj/effect/turf_decal/caution{
+	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/area/f13/brotherhood)
+"aAk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/armor/bos_vault_armor,
-/turf/open/floor/plasteel/vault/side,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
+	},
+/obj/machinery/vending/wardrobe/bar_wardrobe,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "aAv" = (
+/obj/item/ship_in_a_bottle{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/structure/table/wood/fancy/black,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/card/bos,
 /turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "aAJ" = (
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/f13{
@@ -949,13 +1148,15 @@
 	},
 /area/f13/followers)
 "aAX" = (
-/obj/machinery/door/airlock/hatch{
-	id_tag = "knightc1";
-	name = "Knight-Commander Office";
-	req_access_txt = "120"
+/obj/effect/decal/cleanable/greenglow,
+/turf/closed/indestructible/vaultdoor{
+	desc = "A wall built to withstand an atomic explosion.";
+	icon = 'icons/fallout/turfs/walls/vault_reinforced.dmi';
+	icon_state = "vaultrwall0";
+	icon_type_smooth = "vaultrwall";
+	name = "vault reinforced wall"
 	},
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "aBg" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/machinery/light/broken{
@@ -964,15 +1165,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/building/museum)
 "aBm" = (
-/obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "aBz" = (
-/obj/structure/chair/sofa/corp/corner,
+/obj/structure/target_stake{
+	anchored = 1
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
 "aCD" = (
 /obj/structure/junk/small/tv{
 	pixel_y = 20
@@ -981,44 +1186,29 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "aDq" = (
-/obj/item/clothing/suit/armor/f13/combat/brotherhood,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood,
-/obj/item/clothing/mask/gas/sechailer/swat,
-/obj/item/clothing/mask/gas/sechailer/swat,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood,
-/obj/item/clothing/mask/gas/sechailer/swat,
-/obj/item/clothing/mask/gas/sechailer/swat,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/military,
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
+/obj/structure/chair/bench{
+	dir = 4;
+	pixel_y = 1;
+	pixel_x = -7
 	},
-/obj/machinery/light{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/bot_red,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
+"aDt" = (
+/obj/structure/chair/office/dark{
+	dir = 1;
+	icon_state = "officechair_dark"
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 4
-	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "aEf" = (
-/obj/machinery/door/airlock/hatch{
-	id_tag = "Marshal1";
-	name = "Marshal Office";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/darkred,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "aEk" = (
 /obj/structure/nest/spider{
 	max_mobs = 2
@@ -1032,22 +1222,15 @@
 	},
 /area/f13/followers)
 "aEY" = (
-/obj/structure/curtain{
-	color = "#845f58";
-	pixel_x = -32
-	},
-/obj/structure/closet,
-/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
-/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
-/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
-/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
-/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
-/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/area/f13/brotherhood/archives)
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/turf/open/water,
+/area/f13/brotherhood)
 "aGd" = (
 /turf/open/floor/f13/wood,
 /area/f13/caves)
@@ -1056,20 +1239,13 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "aGN" = (
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 8
+/obj/machinery/plantgenes,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood)
 "aHf" = (
 /obj/machinery/button/door{
 	id = "militarystorage2";
@@ -1082,26 +1258,43 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "aIM" = (
-/obj/item/flag/bos{
-	density = 0;
-	pixel_y = 30
+/obj/machinery/vending/wallmed{
+	pixel_x = -30
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "aIP" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
+/obj/machinery/power/am_control_unit{
+	anchored = 1;
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/armory)
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "bosengine"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood)
 "aJq" = (
-/turf/closed/wall/r_wall/rust,
+/obj/structure/closet,
+/obj/item/storage/box/gloves,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/obj/item/wrench/medical,
+/obj/item/toy/figure/cmo{
+	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
+	layer = 2;
+	name = "Head Scribe Action Figure";
+	toysay = "Ad astra per aspera."
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood)
 "aJB" = (
 /mob/living/simple_animal/hostile/raider/baseball{
@@ -1112,18 +1305,49 @@
 	},
 /area/f13/tunnel)
 "aJF" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred,
-/area/f13/brotherhood/armory)
-"aKk" = (
-/obj/structure/toilet{
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/structure/closet/crate{
+	anchored = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
+"aJI" = (
+/obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
+/obj/item/stack/sheet/prewar/five,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/item/stack/sheet/prewar/five,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "white"
-	},
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
+"aKk" = (
+/obj/structure/weightmachine/weightlifter,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "aKr" = (
 /obj/machinery/mineral/mint,
 /obj/item/stack/sheet/metal/fifty,
@@ -1132,8 +1356,13 @@
 	},
 /area/f13/tunnel/bighorn)
 "aLF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/archives)
+/area/f13/brotherhood)
 "aLP" = (
 /turf/open/floor/f13{
 	icon_state = "darkredfull"
@@ -1155,9 +1384,20 @@
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "aNu" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/circuitboard/machine/monkey_recycler,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/brotherhood)
 "aOk" = (
 /obj/machinery/light{
@@ -1167,41 +1407,84 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel/bighorn)
-"aPj" = (
-/obj/machinery/firealarm{
-	name = "INTRUDER ALERT"
+"aOm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/junglebush/b,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
 	},
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/brotherhood/leisure)
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/light_emitter,
+/turf/open/water,
+/area/f13/brotherhood)
+"aPj" = (
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
 "aPS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building/museum)
-"aQB" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Scribe Quarters"
+"aQb" = (
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/item/clipboard{
+	pixel_x = 32
 	},
+/obj/item/clipboard{
+	pixel_x = 34
+	},
+/obj/item/clipboard{
+	pixel_x = 36
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/dorms)
+/area/f13/brotherhood)
+"aQB" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "QMLoad"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
+"aRp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/brotherhood)
 "aRA" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/wine{
-	pixel_x = -5;
-	pixel_y = 15
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_x = 7;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_x = 7;
-	pixel_y = 3
-	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/dorms)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "aTo" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -1212,54 +1495,49 @@
 	},
 /area/f13/building/massfusion)
 "aTI" = (
-/obj/item/circuitboard/machine/emitter/siege,
-/obj/item/circuitboard/machine/emitter/siege,
-/obj/item/circuitboard/machine/emitter/siege,
-/obj/item/circuitboard/machine/emitter/siege,
-/obj/structure/closet/crate/secure/weapon,
-/obj/effect/turf_decal/bot_red,
+/obj/machinery/chem_master/advanced,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 6
-	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "aTN" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/vault/side,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood)
 "aTZ" = (
-/obj/structure/chair/bench,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
+/obj/machinery/computer/rdconsole/core/bos{
+	desc = "The Head Scribe's terminal. Better not touch it, i'll get chewed out.";
+	name = "Head Scribe's Archive Terminal"
 	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "aUl" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Knight Quarters"
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/carpet/purple,
+/area/f13/brotherhood)
 "aUy" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "aVj" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 8
+/turf/open/floor/f13{
+	dir = 4;
+	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood)
 "aVt" = (
-/obj/structure/railing{
-	dir = 9
+/obj/structure/table/glass,
+/obj/item/storage/bag/chemistry{
+	pixel_x = 10;
+	pixel_y = 14
 	},
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "bosrec"
-	},
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "aXt" = (
@@ -1289,20 +1567,33 @@
 	},
 /area/f13/building/massfusion)
 "aYb" = (
-/obj/machinery/workbench/forge,
-/turf/open/floor/plasteel/darkred/side,
-/area/f13/brotherhood/armory)
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "120"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "aZt" = (
 /turf/open/floor/f13/wood,
 /area/f13/tunnel/bighorn)
-"baR" = (
-/obj/machinery/recycler,
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "bosrec"
+"aZE" = (
+/obj/structure/sign/poster/official/work_for_a_future{
+	pixel_x = 32
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/brotherhood)
+"baR" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/brotherhood)
 "bcB" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -1314,18 +1605,28 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/museum)
 "beo" = (
-/obj/structure/chair/sofa/corp/left,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/dorms)
-"beW" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/box,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 5
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 1;
+	pixel_y = 18
 	},
-/area/f13/brotherhood/archives)
+/obj/structure/fence/handrail{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood)
+"beW" = (
+/obj/structure/table/wood/settler,
+/obj/item/pizzabox,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "bgi" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 9
@@ -1358,18 +1659,26 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/museum)
 "bhF" = (
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/turf/open/water,
+/area/f13/brotherhood)
+"bhS" = (
+/obj/structure/chair/bench,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 1
-	},
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "bhT" = (
 /obj/structure/chair/wood{
@@ -1377,6 +1686,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"bhZ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
 "biD" = (
 /obj/structure/nest/ghoul{
 	max_mobs = 2
@@ -1384,14 +1701,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "biK" = (
-/obj/structure/railing{
-	dir = 5
-	},
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "bosrec"
-	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/carpet,
 /area/f13/brotherhood)
 "biU" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -1412,21 +1724,29 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/building/massfusion)
 "bkj" = (
-/obj/machinery/light{
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 8
-	},
-/area/f13/brotherhood/armory)
+/turf/open/water,
+/area/f13/brotherhood)
 "bkS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 1;
+	pixel_y = 18
 	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 4
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood)
 "blr" = (
@@ -1442,11 +1762,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "blY" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "QMLoad"
-	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood)
 "bma" = (
 /obj/structure/closet/fridge,
@@ -1461,22 +1778,21 @@
 /turf/open/floor/wood/wood_common,
 /area/f13/tunnel/bighorn)
 "bot" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	layer = 2.7;
+	name = "prewar lounge chair"
 	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
-	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "boy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "120"
 	},
-/obj/machinery/conveyor{
-	dir = 5;
-	id = "QMUnload"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
 "boD" = (
 /obj/structure/chair/wood{
@@ -1506,9 +1822,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "bpy" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/circuitboard/machine/experimentor,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/brotherhood)
 "bpI" = (
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
@@ -1571,16 +1888,35 @@
 /obj/item/reagent_containers/food/drinks/bottle/brown/greenwine,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/tunnel/bighorn)
+"bsm" = (
+/obj/structure/table/wood,
+/obj/item/toy/figure/hos{
+	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
+	name = "Head Paladin Action Figure";
+	toysay = "SEMPER INVICTA!"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "bsC" = (
 /turf/closed/wall/rust,
 /area/f13/tunnel)
 "bsE" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/lattice/catwalk,
+/obj/machinery/hydroponics/constructable,
+/obj/structure/decoration/smokeold{
+	pixel_y = 32
 	},
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	barefootstep = "water";
+	clawfootstep = "water";
+	desc = "Shallow water.";
+	footstep = "water";
+	heavyfootstep = "water";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "riverwater_motion";
+	name = "water"
+	},
+/area/f13/brotherhood)
 "bsK" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -1590,6 +1926,20 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/building/museum)
+"btm" = (
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/syndicate/brotherhood,
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
+	},
+/obj/item/clothing/suit/toggle/labcoat/scribecoat,
+/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
+/turf/open/floor/carpet/purple,
+/area/f13/brotherhood)
 "btN" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
@@ -1603,11 +1953,15 @@
 	},
 /area/f13/tunnel)
 "bvu" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 6
+/obj/structure/table,
+/obj/machinery/computer/terminal,
+/obj/machinery/camera/autoname{
+	dir = 6;
+	name = "South Facing Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood)
 "bvJ" = (
@@ -1625,9 +1979,14 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bwr" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/armory)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "bwx" = (
 /obj/structure/chair/sofa/corner,
 /turf/open/floor/f13/wood{
@@ -1671,10 +2030,48 @@
 /obj/item/clothing/mask/gas/syndicate,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"bxV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet{
+	anchored = 1;
+	name = "formal attire closet"
+	},
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood)
 "byp" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"byQ" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "bzQ" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt,
@@ -1758,24 +2155,24 @@
 /area/f13/bunker)
 "bCp" = (
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 8
-	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "bCt" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/tunnel)
 "bCy" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "QMLoad"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 5
+/obj/structure/fence/handrail{
+	dir = 4;
+	pixel_x = -15
 	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
 "bCG" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/inside/mountain,
@@ -1847,12 +2244,12 @@
 /turf/closed/wall/mineral/concrete,
 /area/f13/building/museum)
 "bEk" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/door/airlock/grunge{
+	id_tag = "sentdorm";
+	req_access_txt = "120"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "bEo" = (
 /obj/structure/decoration/vent{
 	pixel_x = 16;
@@ -1894,11 +2291,10 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/tunnel)
 "bEX" = (
-/obj/machinery/firealarm{
-	name = "INTRUDER ALERT"
-	},
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/brotherhood/offices1st)
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/area/f13/brotherhood)
 "bFx" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/tunnel)
@@ -4709,7 +5105,9 @@
 /area/f13/sewer)
 "bRg" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault/side,
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood)
 "bRi" = (
 /obj/item/flashlight/lantern,
@@ -4843,11 +5241,24 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "bSF" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal{
-	termtag = "Business"
+/obj/machinery/light/fo13colored/Aqua{
+	brightness = 3;
+	critical_machine = 1;
+	dir = 8;
+	flicker_chance = 0;
+	icon_state = "bulb";
+	name = "Light Bulb"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/bottle/instacoffee{
+	pixel_y = 10;
+	pixel_x = -9
+	},
+/obj/item/reagent_containers/food/drinks/bottle/instacoffee{
+	pixel_y = 10;
+	pixel_x = 4
+	},
+/turf/open/floor/plasteel/darkpurple,
 /area/f13/brotherhood)
 "bSG" = (
 /obj/structure/nest/molerat{
@@ -4871,11 +5282,13 @@
 	},
 /area/f13/bunker)
 "bTe" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "bTh" = (
 /obj/docking_port/stationary/bosaway/twelve{
 	name = "Near the Museum"
@@ -4917,15 +5330,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "bUj" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	icon_state = "rightsecure"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/brotherhood/reactor)
+/obj/structure/table/wood/poker,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/purple,
+/area/f13/brotherhood)
 "bUo" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -5065,6 +5473,12 @@
 "bXq" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkred/side{
 	dir = 10
 	},
@@ -5090,11 +5504,21 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"bYo" = (
-/obj/machinery/photocopier,
+"bXU" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side,
-/area/f13/brotherhood/offices1st)
+/obj/structure/simple_door/bunker/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
+"bYo" = (
+/obj/structure/chair/booth{
+	icon_state = "booth_east_north"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
 "bYt" = (
 /obj/structure/handrail/g_central{
 	dir = 1;
@@ -5108,11 +5532,16 @@
 	},
 /area/f13/tunnel)
 "bYF" = (
-/obj/item/pet_carrier,
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "120"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "bZk" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/indestructible/ground/inside/mountain,
@@ -5128,6 +5557,14 @@
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"bZr" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "bZt" = (
 /obj/structure/girder,
 /obj/structure/barricade/wooden/planks,
@@ -5136,6 +5573,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
+"bZv" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "bZB" = (
 /obj/structure/table/wood/junk,
 /turf/open/floor/f13{
@@ -5202,6 +5647,11 @@
 /obj/item/trash/f13/cram_large,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"cbR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/jukebox,
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
 "ccc" = (
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/indestructible/ground/inside/mountain,
@@ -5218,12 +5668,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ccI" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
+/obj/machinery/libraryscanner{
+	desc = "This device scans books and other documents for entry into the Archives.";
+	name = "archive scanner";
+	pixel_y = 7
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
 /turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "ccS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/prewar/poster65{
@@ -5244,32 +5696,23 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "cdu" = (
-/obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault/side{
-	dir = 1
-	},
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "cdI" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/chair/stool/retro/backed{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/workbench/advanced,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
-	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
 "cdO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 10
+/obj/structure/barricade/bars,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood)
 "cdP" = (
@@ -5277,13 +5720,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "cdV" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 5
-	},
-/area/f13/brotherhood/armory)
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "ceq" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/machinery/light/small{
@@ -5294,12 +5735,14 @@
 /area/f13/tunnel)
 "ceF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/hatch{
-	id_tag = "scribes1";
-	name = "Scribe Quarters"
+/obj/machinery/computer/terminal{
+	icon = 'icons/obj/machines/particle_accelerator.dmi';
+	icon_keyboard = "generic_key";
+	icon_screen = "generic";
+	icon_state = "control_boxp"
 	},
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "ceO" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/inside/mountain,
@@ -5308,11 +5751,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "ceX" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 4
+/obj/structure/table{
+	layer = 2.9
 	},
-/area/f13/brotherhood/archives)
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "cfv" = (
 /obj/item/storage/fancy/donut_box,
 /turf/open/indestructible/ground/inside/mountain,
@@ -5387,16 +5834,26 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "cgy" = (
-/obj/machinery/shower{
-	dir = 1
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/structure/rack/shelf_metal,
+/obj/item/stock_parts/cell/super{
+	pixel_y = -6
 	},
-/obj/structure/curtain,
-/obj/structure/decoration/vent,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
+/obj/item/stock_parts/cell/super{
+	pixel_y = -6
 	},
-/area/f13/brotherhood/leisure)
+/obj/item/stock_parts/cell/super{
+	pixel_y = -6
+	},
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "cgV" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superlow,
@@ -5414,6 +5871,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel/bighorn)
+"chv" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "chJ" = (
 /turf/closed/wall/r_wall,
 /area/f13/tcoms)
@@ -5467,10 +5931,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "ciN" = (
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
+/obj/machinery/vending/wallmed{
+	pixel_x = -32
 	},
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "ciX" = (
 /obj/structure/closet/fridge,
@@ -5938,9 +6402,10 @@
 /turf/open/floor/plasteel/grimy,
 /area/f13/tunnel)
 "coH" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/dorms)
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/window/reinforced,
+/turf/open/water,
+/area/f13/brotherhood)
 "coI" = (
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /turf/open/floor/plating/tunnel,
@@ -6048,9 +6513,11 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
 "cvx" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/circuitboard/machine/sleeper,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/bench{
+	pixel_y = 15
+	},
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood)
 "cvC" = (
 /obj/item/instrument/accordion,
@@ -6175,12 +6642,11 @@
 	},
 /area/f13/tunnel)
 "cyI" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 1
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood)
 "cyS" = (
@@ -6235,25 +6701,15 @@
 	},
 /area/f13/tunnel)
 "cAN" = (
-/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
-	},
-/area/f13/brotherhood/archives)
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
 "cAT" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "QMUnload"
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/rack/shelf_metal,
+/obj/item/circuitboard/machine/ore_silo,
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood)
 "cAX" = (
 /obj/docking_port/stationary/bosaway/nine{
@@ -6262,19 +6718,17 @@
 /turf/closed/wall/rust,
 /area/f13/tunnel)
 "cBX" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "cDu" = (
-/obj/structure/closet,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
-/obj/item/storage/box/gloves,
-/obj/item/storage/box/gloves,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/turf/open/floor/plasteel/freezer,
-/area/f13/brotherhood/medical)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood)
 "cDS" = (
 /obj/structure/sign/poster/contraband/have_a_puff{
 	pixel_y = 32
@@ -6289,9 +6743,21 @@
 	},
 /area/f13/tunnel)
 "cEz" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/circuitboard/machine/mech_recharger,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/obj/structure/table/reinforced,
+/obj/item/paper,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
+"cFq" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Elder's Office";
+	req_access_txt = "120"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "cGq" = (
 /obj/machinery/light{
@@ -6312,9 +6778,13 @@
 	},
 /area/f13/tunnel/bighorn)
 "cHM" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/brotherhood/reactor)
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "cHS" = (
 /obj/structure/railing{
 	dir = 4
@@ -6323,15 +6793,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/tunnel/bighorn)
 "cHT" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 1
-	},
+/obj/structure/bookcase/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "cKl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6344,9 +6808,14 @@
 	},
 /area/f13/tunnel)
 "cLp" = (
-/obj/machinery/door/unpowered/secure_bos,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "bcircuit1";
+	light_color = "#0076bc";
+	light_power = 3;
+	light_range = 4
+	},
+/area/f13/brotherhood)
 "cLC" = (
 /mob/living/simple_animal/hostile/raider/ranged/biker{
 	name = "Tunnel Torturers Raider"
@@ -6385,16 +6854,20 @@
 	},
 /area/f13/tunnel)
 "cOG" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/item/flashlight/lamp{
+	pixel_x = -14;
+	pixel_y = 9
 	},
-/obj/item/storage/fancy/donut_box,
+/obj/item/reagent_containers/food/drinks/mug/tea{
+	name = "bitter black coffee";
+	pixel_x = 4;
+	pixel_y = 7
+	},
 /turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood)
 "cPu" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/generic,
@@ -6420,10 +6893,24 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/building/museum)
 "cRP" = (
-/obj/structure/chair/comfy/black,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/card/bos{
+	dir = 1
+	},
+/obj/item/card/id/dogtag,
+/obj/item/card/id/dogtag,
+/obj/item/card/id/dogtag,
 /turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
+"cRX" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Knight Commander's Office";
+	req_access_txt = "120"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/r_wall/f13/vault,
+/area/f13/brotherhood)
 "cSO" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4"
@@ -6456,68 +6943,68 @@
 	},
 /area/f13/tunnel/bighorn)
 "cTh" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/circuitboard/machine/biogenerator,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/obj/machinery/vending/nukacolavendfull,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "cTr" = (
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
-	},
+/obj/structure/chair/stool/retro/black,
+/obj/effect/landmark/start/f13/seniorscribe,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 8
-	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "cTY" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "120"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "cWd" = (
 /obj/structure/railing{
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
+"cWz" = (
+/obj/effect/decal/cleanable/ash/large,
+/obj/effect/decal/cleanable/ash/crematorium,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "cXk" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "cYq" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/corner{
-	dir = 8
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood)
 "cYU" = (
-/obj/machinery/button/door{
-	id = "knights1";
-	name = "Knights Room 1";
-	normaldoorcontrol = 1;
-	pixel_x = 32;
-	req_access_txt = "120";
-	specialfunctions = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "cZw" = (
 /obj/effect/spawner/lootdrop/f13/blueprintLow,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "cZy" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/machinery/processor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhdirty_chess2"
+	},
+/area/f13/brotherhood)
 "cZC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6525,11 +7012,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building/museum)
 "cZL" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 1;
+	icon_state = "twindowold"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood)
 "das" = (
 /obj/structure/fermenting_barrel,
 /obj/structure/railing/wood{
@@ -6561,13 +7049,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel/bighorn)
 "dbG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/card/bos{
-	density = 0;
-	pixel_y = 18
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "dbK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6580,37 +7066,50 @@
 	},
 /area/f13/building/massfusion)
 "dbO" = (
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood)
+"dcl" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/closet/radiation{
+	anchored = 1
 	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 4
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_y = 32
 	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "dcx" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
 /area/f13/tunnel/bighorn)
-"ddN" = (
-/obj/machinery/rnd/destructive_analyzer,
-/obj/structure/window/reinforced/tinted{
-	dir = 4
-	},
-/obj/item/stack/sheet/mineral/abductor,
-/turf/open/floor/plasteel/darkpurple/side,
-/area/f13/brotherhood/archives)
-"dee" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/status_display/supply{
-	pixel_y = 32
-	},
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "QMUnload"
+"ddo" = (
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
 	},
 /turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
+"ddN" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5;
+	pixel_x = -12
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 10;
+	pixel_x = -12
+	},
+/obj/item/clothing/gloves/boxing{
+	pixel_x = -12
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
+"dee" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/grimy,
 /area/f13/brotherhood)
 "deg" = (
 /obj/structure/bed/mattress{
@@ -6625,6 +7124,17 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"dfq" = (
+/obj/machinery/door/airlock/grunge{
+	id_tag = "bossecgear";
+	name = "Internal Security Gear";
+	req_access_txt = "120"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "dfy" = (
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -6656,12 +7166,13 @@
 	},
 /area/f13/tunnel)
 "djF" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "djT" = (
 /obj/effect/landmark/start/f13/followersadministrator,
 /obj/structure/chair/stool/f13stool,
@@ -6675,15 +7186,15 @@
 	},
 /area/f13/building/museum)
 "dky" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Armory";
-	req_access_txt = "120"
+/obj/machinery/workbench,
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = 12
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood)
 "dlb" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13{
@@ -6725,17 +7236,20 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel/bighorn)
+"dlz" = (
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
+	dir = 8;
+	name = "prewar lounge chair"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "dlD" = (
-/obj/effect/turf_decal/caution{
-	dir = 4
+/obj/structure/chair/wood{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "QMLoad"
-	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "dlV" = (
 /obj/machinery/vending/medical{
@@ -6747,9 +7261,8 @@
 	},
 /area/f13/followers)
 "dmc" = (
-/obj/structure/mirror,
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "dmm" = (
 /obj/item/ammo_casing/shotgun/buckshot,
 /obj/structure/wreck/trash/engine,
@@ -6764,12 +7277,20 @@
 	},
 /area/f13/tunnel/bighorn)
 "doL" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "white"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/brotherhood/medical)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhdirty_chess2"
+	},
+/area/f13/brotherhood)
 "dpy" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13{
@@ -6784,18 +7305,21 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel/bighorn)
 "dqX" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/brotherhood/medical)
-"dqY" = (
+/obj/structure/chair/comfy,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname{
+	dir = 6;
+	name = "South Facing Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
+"dqY" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/f13{
-	icon_state = "white"
-	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "dqZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/sign{
@@ -6850,25 +7374,22 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "duV" = (
-/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/light/floor,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault/side,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/brotherhood)
 "dvB" = (
-/obj/machinery/door/airlock/survival_pod/glass{
-	name = "cell airlock";
-	req_access_txt = "120"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/mineral/plastitanium,
+/obj/structure/chair/wood,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "dwx" = (
-/obj/structure/grille,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/archives)
+/obj/structure/chair/bench,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "dwF" = (
 /obj/structure/lattice/catwalk,
 /turf/open/indestructible/ground/outside/water,
@@ -6885,10 +7406,17 @@
 	},
 /area/f13/tunnel/bighorn)
 "dxA" = (
-/turf/open/floor/plasteel/darkred/corner{
-	dir = 4
+/obj/structure/rack,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood)
 "dya" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder,
@@ -6911,24 +7439,28 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "dzS" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Armory";
-	req_access_txt = "120"
+/obj/structure/toilet{
+	dir = 4
 	},
-/turf/open/floor/plasteel/vault,
-/area/f13/brotherhood/armory)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood)
 "dAo" = (
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/under/f13/bosformgold_m,
-/obj/item/clothing/under/f13/bosformgold_f,
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
+/obj/structure/bookcase/manuals/research_and_development{
+	allowed_books = list(/obj/item/book,/obj/item/book,/obj/item/storage/book,/obj/item/book,/obj/item/book,/obj/item/book);
+	desc = "A collection of scrolls, archives and relics.";
+	name = "Brotherhood Historical Archives"
 	},
-/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood)
 "dAL" = (
 /obj/machinery/light{
 	dir = 1;
@@ -6947,9 +7479,18 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dDm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/offduty,
-/turf/open/floor/plasteel/vault/side,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "dDJ" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -6974,8 +7515,13 @@
 	},
 /area/f13/building/massfusion)
 "dEl" = (
-/turf/open/floor/plasteel/darkred,
-/area/f13/brotherhood/armory)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "dEo" = (
 /obj/machinery/shower{
 	dir = 8
@@ -6984,11 +7530,14 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel/bighorn)
 "dFf" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "bosengine";
+	name = "Radiation Shutters";
+	pixel_x = -32
 	},
-/turf/open/floor/plasteel/freezer,
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood)
 "dFj" = (
 /obj/machinery/light{
 	dir = 8
@@ -7003,9 +7552,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dFC" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/circuitboard/machine/dna_vault,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "dFM" = (
 /obj/item/stack/sheet/mineral/sandbags,
@@ -7051,32 +7598,26 @@
 /turf/open/floor/plating,
 /area/f13/building/museum)
 "dIo" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault/side{
-	dir = 4
-	},
+/obj/structure/bed/pod,
+/obj/item/bedsheet/hos,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "dIS" = (
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel/bighorn)
 "dJd" = (
-/obj/structure/filingcabinet,
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/door/airlock/grunge{
+	id_tag = "sentdorm";
+	req_access_txt = "120"
 	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 4
-	},
-/area/f13/brotherhood/archives)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "dKt" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "dLk" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -7091,15 +7632,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "dLM" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/smes/engineering,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/wardrobe/science_wardrobe,
+/turf/open/floor/carpet/purple,
 /area/f13/brotherhood)
 "dMj" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/vault,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood)
 "dMD" = (
 /obj/structure/handrail/g_central{
@@ -7120,16 +7662,14 @@
 	},
 /area/f13/brotherhood)
 "dNs" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
-	},
-/area/f13/brotherhood/archives)
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/caves)
 "dNu" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plasteel/darkred,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
+	},
 /area/f13/brotherhood)
 "dNM" = (
 /obj/structure/railing{
@@ -7151,24 +7691,44 @@
 	},
 /area/f13/building/massfusion)
 "dQF" = (
-/obj/structure/closet/cabinet,
-/obj/machinery/light{
+/obj/structure/bookcase/manuals/research_and_development{
+	allowed_books = list(/obj/item/book,/obj/item/book,/obj/item/storage/book,/obj/item/book,/obj/item/book,/obj/item/book);
+	desc = "A collection of scrolls, archives and relics.";
+	name = "Brotherhood Historical Archives"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood)
+"dRJ" = (
+/obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/dorms)
-"dSb" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
-"dSr" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/hatch{
-	name = "Research";
-	req_access_txt = "120"
+/obj/structure/table{
+	layer = 2.9
 	},
 /turf/open/floor/plasteel/darkpurple,
-/area/f13/brotherhood/archives)
+/area/f13/brotherhood)
+"dSb" = (
+/obj/structure/chair/booth{
+	icon_state = "booth_west_north"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
+"dSr" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/bos{
+	circuit = /obj/item/circuitboard/computer/security;
+	dir = 8;
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood)
 "dTa" = (
 /turf/open/floor/plasteel/darkpurple/side{
 	dir = 1
@@ -7220,14 +7780,28 @@
 	},
 /area/f13/tunnel)
 "dWc" = (
-/turf/open/floor/plasteel/vault/side{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood)
 "dWd" = (
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/brotherhood/medical)
+/obj/structure/table/survival_pod,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 12
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 5
+	},
+/obj/item/newspaper{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood)
 "dWl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bodypart/l_arm,
@@ -7251,9 +7825,17 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "dXl" = (
-/obj/machinery/door/airlock/medical,
-/turf/open/floor/plasteel/freezer,
-/area/f13/brotherhood/medical)
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/recharger,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "dYw" = (
 /obj/machinery/workbench,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -7279,12 +7861,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel/bighorn)
 "dYS" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 10
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/grimy,
 /area/f13/brotherhood)
 "dYU" = (
 /obj/effect/decal/cleanable/generic,
@@ -7297,11 +7878,35 @@
 	},
 /area/f13/building/massfusion)
 "dZP" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
 	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 1
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 5;
+	name = "Reactor Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood)
 "eaV" = (
@@ -7311,34 +7916,37 @@
 	},
 /area/f13/tunnel/bighorn)
 "ebG" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 10
+/obj/machinery/conveyor/inverted{
+	dir = 6;
+	id = "QMLoad"
 	},
-/turf/open/floor/mineral/plastitanium,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood)
 "ebV" = (
 /obj/item/storage/box/lights/tubes,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/building/museum)
 "ech" = (
-/obj/machinery/button/crematorium{
-	id = "BOS Crematorium"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/brotherhood/medical)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "ecF" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "BOS"
+/obj/structure/simple_door/bunker{
+	name = "Ceremony Room";
+	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "edy" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -7355,24 +7963,24 @@
 	},
 /area/f13/tunnel/bighorn)
 "edO" = (
-/obj/machinery/autolathe/constructionlathe,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 10
+/obj/structure/curtain{
+	color = "#5c131b"
 	},
-/area/f13/brotherhood/archives)
+/obj/structure/simple_door/bunker/glass,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "edQ" = (
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/clothing/under/f13/bosformgold_f,
-/obj/item/clothing/under/f13/bosformgold_m,
-/obj/item/clothing/head/f13/boscap,
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
+/obj/structure/chair/bench{
+	dir = 4;
+	pixel_y = 1;
+	pixel_x = -7
 	},
-/obj/effect/spawner/lootdrop/f13/cash_random_high,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "eed" = (
 /obj/structure/table/wood/settler{
 	name = "stage"
@@ -7388,6 +7996,15 @@
 	icon_state = "whiterustysolid"
 	},
 /area/f13/tunnel)
+"egw" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
 "egP" = (
 /obj/structure/billboard/cola/pristine,
 /turf/open/floor/f13{
@@ -7395,16 +8012,32 @@
 	},
 /area/f13/tunnel/bighorn)
 "ehp" = (
-/turf/open/floor/plasteel/darkbrown/side{
+/obj/structure/bookcase/random/religion{
+	desc = "A collection of scrolls, archives and relics.";
+	name = "Religious References"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood)
+"eif" = (
+/obj/structure/chair/sofa/corp/right{
 	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood)
 "eii" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 10
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/area/f13/brotherhood/armory)
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
 "eiq" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib2-old"
@@ -7421,25 +8054,40 @@
 	},
 /area/f13/building/massfusion)
 "eix" = (
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = 32
 	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/dorms)
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "ejI" = (
 /turf/open/indestructible/ground/inside/subway{
 	name = "stone floor"
 	},
 /area/f13/caves)
 "ejL" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
+/obj/structure/lattice{
+	layer = 3
 	},
-/area/f13/brotherhood/leisure)
+/obj/machinery/light/floor{
+	critical_machine = 1;
+	flicker_chance = 0
+	},
+/obj/item/cigbutt{
+	anchored = 1;
+	color = "#808080";
+	pixel_x = 11;
+	pixel_y = 9
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "ejN" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/inside/mountain,
@@ -7471,6 +8119,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/followers)
+"enq" = (
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "120"
+	},
+/turf/closed/wall/r_wall/f13/vault,
+/area/f13/brotherhood)
 "enI" = (
 /obj/structure/table/wood,
 /obj/structure/curtain{
@@ -7493,8 +8147,21 @@
 	},
 /area/f13/tunnel)
 "eof" = (
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/darkred/side,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced{
+	alpha = 0;
+	desc = "Secure bolting to support the heavy weight of power armor.";
+	name = "frame support bolts"
+	},
+/obj/structure/kitchenspike_frame{
+	anchored = 1;
+	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
+	name = "power armor frame"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
 /area/f13/brotherhood)
 "eoj" = (
 /obj/structure/chair/wood,
@@ -7508,13 +8175,26 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/tunnel)
-"epj" = (
-/obj/structure/table/glass,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "white"
+"eoV" = (
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
 	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
+"epj" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Security Checkpoint";
+	req_access_txt = "120"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood)
 "ept" = (
 /obj/machinery/shower{
 	pixel_y = 32
@@ -7546,13 +8226,11 @@
 	},
 /area/f13/building/massfusion)
 "equ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "white"
-	},
-/area/f13/brotherhood/medical)
+/obj/effect/turf_decal/box,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
 "erZ" = (
 /obj/structure/barricade/bars,
 /obj/structure/curtain{
@@ -7592,21 +8270,34 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"etT" = (
-/obj/machinery/power/am_control_unit,
+"ety" = (
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/turf/open/floor/carpet/purple,
+/area/f13/brotherhood)
+"etT" = (
+/obj/item/flashlight/lamp{
+	pixel_x = -14;
+	pixel_y = 9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/brotherhood/reactor)
+/obj/item/reagent_containers/food/drinks/mug/tea{
+	name = "bitter black coffee";
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/structure/table{
+	pixel_y = 6
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "euM" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
+/obj/structure/bookcase/manuals/engineering,
+/obj/machinery/light/small{
+	dir = 1
 	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "euN" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -7678,21 +8369,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "eBa" = (
-/obj/structure/rack,
 /obj/effect/turf_decal/box,
-/obj/item/integrated_electronics/analyzer,
-/obj/item/integrated_electronics/debugger,
-/obj/item/integrated_electronics/detailer,
-/obj/item/integrated_electronics/wirer,
-/obj/item/integrated_circuit_printer,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 9
-	},
-/area/f13/brotherhood/archives)
+/obj/structure/cable,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/area/f13/brotherhood)
 "eBc" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/circuitboard/machine/grounding_rod,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/darkpurple,
 /area/f13/brotherhood)
 "eCp" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -7712,9 +8399,29 @@
 /obj/effect/spawner/lootdrop/ammo/military,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/massfusion)
+"eDg" = (
+/obj/structure/table/wood/fancy/black,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "eDK" = (
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel/bighorn)
+"eDN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname{
+	dir = 6;
+	name = "South Facing Camera";
+	network = list("BoS")
+	},
+/obj/structure/chalkboard,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "eEP" = (
 /obj/structure/railing{
 	dir = 8
@@ -7731,17 +8438,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "eFw" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/item/stack/sheet/prewar/five,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side,
-/area/f13/brotherhood/armory)
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowright"
+	},
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "eFV" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/ghoul,
@@ -7789,14 +8493,16 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "eIt" = (
-/obj/structure/closet/locker,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowright"
 	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "eIw" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkbrown/side,
+/obj/effect/decal/cleanable/ash/crematorium,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "eIZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7828,21 +8534,20 @@
 	},
 /area/f13/building/massfusion)
 "eJV" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Power";
-	req_access_txt = "120"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "eKy" = (
-/obj/structure/decoration/sign{
-	desc = "The Keeper takes care of supplying and buying for projects the scribes are doing while keeping the train filled with supply points.";
-	name = "The Keeper"
+/obj/structure/window/fulltile/store{
+	layer = 2.9
 	},
-/turf/closed/wall/r_wall/f13/vault,
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowtop"
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "eKJ" = (
 /obj/structure/chair/sofa/right,
@@ -7859,11 +8564,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/museum)
 "eLA" = (
-/obj/structure/bed/mattress/pregame,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "eLJ" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
@@ -7897,18 +8600,24 @@
 	},
 /area/f13/building/massfusion)
 "eOS" = (
-/obj/structure/rack,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 8
+/obj/structure/lattice/catwalk,
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
 	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	barefootstep = "water";
+	clawfootstep = "water";
+	desc = "Shallow water.";
+	footstep = "water";
+	heavyfootstep = "water";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "riverwater_motion";
+	name = "water"
+	},
+/area/f13/brotherhood)
 "ePX" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old"
@@ -7916,12 +8625,17 @@
 /obj/item/clothing/head/helmet/skull,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"eQw" = (
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
 "eRL" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/structure/simple_door/bunker/glass,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "eSw" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 10
@@ -7943,27 +8657,24 @@
 	},
 /area/f13/tunnel/bighorn)
 "eUW" = (
-/obj/structure/table/wood,
-/obj/item/stamp/qm{
-	pixel_x = -4
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_x = 10;
+	pixel_y = 19
 	},
-/obj/item/stamp/denied{
-	pixel_x = 4
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_x = -4;
+	pixel_y = 21
 	},
-/obj/item/stamp,
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "eVM" = (
-/obj/effect/landmark/start/f13/initiate,
-/obj/structure/railing{
-	dir = 8;
-	pixel_x = 32
+/obj/structure/table{
+	pixel_y = 6
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	dir = 1;
-	icon_state = "rampdowntop"
-	},
+/obj/structure/fluff/paper/stack,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "eVN" = (
 /obj/structure/window/reinforced{
@@ -7990,16 +8701,13 @@
 	},
 /area/f13/tunnel)
 "eWJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/mattress/pregame,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/mineral/plastitanium,
+/obj/structure/displaycase/trophy,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "eYn" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall/rust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool,
+/turf/open/floor/carpet/purple,
 /area/f13/brotherhood)
 "eYw" = (
 /obj/machinery/light/small{
@@ -8016,6 +8724,28 @@
 /obj/structure/table,
 /turf/open/floor/wood/wood_common,
 /area/f13/tunnel/bighorn)
+"fcv" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_y = -5;
+	pixel_x = 7
+	},
+/obj/item/pda/chemist{
+	name = "Scribe-Chemist Pip-Boy 3000";
+	pixel_x = 15;
+	pixel_y = 7
+	},
+/obj/machinery/reagentgrinder{
+	layer = 3.3;
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/storage/box/medsprays{
+	pixel_y = -6;
+	pixel_x = -9
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "fcB" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -8027,13 +8757,17 @@
 	},
 /area/f13/tunnel)
 "fcF" = (
-/obj/machinery/door/airlock/hatch{
-	id_tag = "Keeper2";
-	name = "Keeper's Room";
-	req_access_txt = "120"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "bcircuit1";
+	light_color = "#0076bc";
+	light_power = 3;
+	light_range = 4
+	},
+/area/f13/brotherhood)
 "fdG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
@@ -8058,11 +8792,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "ffG" = (
-/obj/structure/bed,
-/obj/item/bedsheet/black,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "fgb" = (
 /obj/effect/turf_decal/huge{
 	dir = 1
@@ -8086,16 +8819,19 @@
 	},
 /area/f13/building/massfusion)
 "fhh" = (
-/obj/effect/landmark/start/f13/sentinel,
-/obj/structure/chair/office/light,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
-"fhn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/plasteel/darkred/corner,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
+"fhn" = (
+/obj/structure/chair/bench{
+	dir = 4;
+	pixel_y = 1;
+	pixel_x = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "fhw" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -8118,11 +8854,25 @@
 	},
 /area/f13/building/massfusion)
 "fjV" = (
-/obj/structure/closet/crate/bin{
-	pixel_y = -10
+/obj/structure/rack,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "fks" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/effect/decal/cleanable/dirt,
@@ -8133,24 +8883,20 @@
 /area/f13/tunnel)
 "fkv" = (
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 5
-	},
-/area/f13/brotherhood/archives)
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
+"flq" = (
+/obj/machinery/mineral/wasteland_vendor,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
 "fml" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/curtain,
-/obj/machinery/shower{
-	pixel_y = 27
+/obj/structure/chair/bench{
+	icon_state = "dropshipleft"
 	},
-/obj/item/soap,
-/obj/structure/decoration/vent,
-/turf/open/floor/f13{
-	icon_state = "white"
-	},
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "fmI" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -8177,28 +8923,39 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "foM" = (
-/obj/structure/table/glass,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door/airlock/hatch{
+	name = "Security Checkpoint";
+	req_access_txt = "120"
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/archives)
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood)
 "fpU" = (
-/obj/machinery/door/unpowered/secure_bos{
-	name = "Morgue"
+/obj/item/pda/captain,
+/obj/structure/table/reinforced,
+/obj/item/folder/syndicate/red{
+	desc = "A folder stamped \"Top Secret - Property of The Brotherhood.\""
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/brotherhood/medical)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "fpZ" = (
-/obj/machinery/msgterminal/brotherhood{
-	density = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/gps/computer{
+	desc = "A large, central database of currently-transmitting GPS signals.";
+	name = "GPS Ping Grabber."
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
+"fqc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood)
 "fqy" = (
 /obj/machinery/light,
 /obj/structure/closet/secure_closet/medical1{
@@ -8229,43 +8986,46 @@
 /turf/closed/wall/rust,
 /area/f13/tunnel)
 "frr" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
-/obj/structure/displaycase,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/structure/window/fulltile/store,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "frx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -11;
+	pixel_y = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/microwave{
+	density = 0;
+	pixel_y = 11
 	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 8
+/obj/machinery/camera/autoname{
+	dir = 6;
+	name = "South Facing Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhdirty_chess2"
 	},
 /area/f13/brotherhood)
 "frP" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "twindowold"
+/obj/structure/table/wood,
+/obj/structure/sign/plaques/kiddie{
+	desc = "A faded sign listing all the less-than-healthy fast foods that were sold here before the world ended.";
+	name = "fast food menu";
+	pixel_y = 32
 	},
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 6
-	},
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
 "fse" = (
-/obj/structure/window/fulltile/store,
-/turf/open/floor/f13{
-	icon_state = "white"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "bosengine"
 	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood)
 "fsu" = (
 /obj/effect/decal/cleanable/chem_pile,
 /turf/open/floor/plasteel/f13{
@@ -8274,17 +9034,19 @@
 /area/f13/building/massfusion)
 "fta" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault/side{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "ftF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/armory)
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "ftM" = (
 /obj/structure/table/wood/poker,
 /obj/item/dice,
@@ -8292,6 +9054,18 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"ful" = (
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/brotherhood)
 "fuD" = (
 /obj/structure/nest/ghoul{
 	max_mobs = 7
@@ -8318,13 +9092,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "fxU" = (
-/obj/structure/railing{
-	dir = 8
+/obj/structure/chair/wood{
+	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "white"
-	},
-/area/f13/brotherhood/medical)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "fyp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/junk/micro,
@@ -8338,6 +9111,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
+"fyE" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood)
 "fyQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -8362,6 +9144,11 @@
 	name = "reactor cooling pool"
 	},
 /area/f13/building/massfusion)
+"fCf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/brotherhood)
 "fCT" = (
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
@@ -8398,12 +9185,20 @@
 	},
 /area/f13/tunnel)
 "fFB" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
 	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/turf/open/water,
 /area/f13/brotherhood)
 "fFG" = (
 /obj/machinery/light/small{
@@ -8417,6 +9212,11 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating,
 /area/f13/building/museum)
+"fGU" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "aesculapius"
+	},
+/area/f13/brotherhood)
 "fGV" = (
 /obj/structure/closet/crate/mortar_shells,
 /obj/item/mortar_kit,
@@ -8448,10 +9248,16 @@
 	},
 /area/f13/building/massfusion)
 "fKd" = (
-/obj/machinery/firealarm{
-	name = "INTRUDER ALERT"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/closed/wall/r_wall/f13/vault,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
+	},
 /area/f13/brotherhood)
 "fKJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8461,8 +9267,12 @@
 	},
 /area/f13/building/massfusion)
 "fLs" = (
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/dorms)
+/obj/structure/junk/small/tv,
+/obj/structure/table/wood/settler,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood)
 "fLv" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -8480,12 +9290,32 @@
 /obj/machinery/power/smes/engineering,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/building/museum)
+"fNu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood)
+"fNX" = (
+/obj/structure/table/wood{
+	pixel_x = 2
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "fOG" = (
 /obj/effect/overlay/junk/oldpipes{
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
+"fPE" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 6;
+	pixel_x = -7
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "fQn" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -8528,18 +9358,16 @@
 	},
 /area/f13/building/massfusion)
 "fSP" = (
-/obj/structure/bed,
-/obj/item/bedsheet/black,
-/obj/machinery/button/door{
-	id = "knights2";
-	name = "Knights Room 2";
-	normaldoorcontrol = 1;
-	pixel_x = 32;
-	req_access_txt = "120";
-	specialfunctions = 4
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/dorms)
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood)
 "fTM" = (
 /obj/structure/noticeboard{
 	dir = 8;
@@ -8562,26 +9390,57 @@
 	},
 /area/f13/tunnel/bighorn)
 "fVC" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 3
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/turf/open/water,
+/area/f13/brotherhood)
+"fVI" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/circuitboard/machine/chem_master/condi,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
+"fWB" = (
+/obj/structure/bookcase/random/reference{
+	desc = "A collection of scrolls, archives and relics.";
+	name = "Archival References"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood)
+"fXa" = (
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	desc = "A console that is capable of accessing the whole of the Brotherhood of Steel's archives. A very important aspect of their organization, this machine is not to be tampered with. Unless sabotage is your goal.";
+	name = "archive database"
+	},
 /obj/structure/table/wood,
 /turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
-"fVI" = (
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 8
-	},
-/area/f13/brotherhood/archives)
+/area/f13/brotherhood)
 "fXj" = (
 /obj/structure/junk/locker,
 /turf/open/floor/plating,
 /area/f13/tunnel/bighorn)
 "fZh" = (
-/obj/machinery/door/airlock/hatch{
-	id_tag = "knightca2";
-	name = "Knight-Captain Bedroom";
-	req_access_txt = "120"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
+	},
+/area/f13/brotherhood)
 "fZl" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -8593,8 +9452,12 @@
 /area/f13/tunnel/bighorn)
 "fZM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/turf/open/floor/plasteel/vault/side,
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "gck" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8609,18 +9472,42 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel/bighorn)
+"gdP" = (
+/obj/structure/table/wood,
+/obj/machinery/bookbinder{
+	icon_state = "bigscanner";
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "gdZ" = (
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/dorms)
+/obj/structure/lattice/catwalk,
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/camera/autoname{
+	dir = 6;
+	name = "South Facing Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	barefootstep = "water";
+	clawfootstep = "water";
+	desc = "Shallow water.";
+	footstep = "water";
+	heavyfootstep = "water";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "riverwater_motion";
+	name = "water"
+	},
+/area/f13/brotherhood)
 "gei" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 4
+/obj/structure/fence,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4;
+	pixel_x = -7
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/dorms)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "gem" = (
 /obj/structure/curtain{
 	color = "#845f58";
@@ -8637,11 +9524,8 @@
 	},
 /area/f13/tunnel)
 "geO" = (
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/brotherhood)
 "geW" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/inside/mountain,
@@ -8672,11 +9556,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel/bighorn)
 "ggS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "white"
+/obj/structure/lattice{
+	density = 1
 	},
-/area/f13/brotherhood/offices1st)
+/obj/structure/table/wood,
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "ghG" = (
 /obj/item/instrument/guitar{
 	anchored = 1;
@@ -8689,35 +9578,55 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "ghI" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
 	},
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/f13/combat/environmental,
-/obj/item/clothing/head/helmet/f13/combat/environmental,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
+/obj/machinery/vending/clothing/bos{
+	density = 0;
+	pixel_x = 32
 	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "gip" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 6
+/obj/structure/lattice/catwalk,
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	barefootstep = "water";
+	clawfootstep = "water";
+	desc = "Shallow water.";
+	footstep = "water";
+	heavyfootstep = "water";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "riverwater_motion";
+	name = "water"
+	},
+/area/f13/brotherhood)
 "giB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/junk/locker,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/museum)
 "giF" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/structure/table/optable,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/brotherhood/medical)
+/obj/item/storage/box/lights/tubes,
+/obj/item/storage/box/lights/bulbs,
+/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/candle_box,
+/obj/item/lipstick/black,
+/obj/item/storage/box/bodybags{
+	pixel_x = -9;
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "giI" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -8733,29 +9642,28 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "gjY" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plasteel/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "gkC" = (
-/obj/structure/closet/crate/bin{
-	density = 0;
-	pixel_y = 27
+/obj/structure/lattice{
+	layer = 3
 	},
-/turf/open/floor/f13{
-	icon_state = "white"
+/obj/machinery/light/floor{
+	critical_machine = 1;
+	flicker_chance = 0
 	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "gkY" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 10
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "white"
-	},
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "glo" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor5-old"
@@ -8768,6 +9676,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
+"gnJ" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname{
+	dir = 6;
+	name = "South Facing Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "gnT" = (
 /obj/machinery/light{
 	dir = 4
@@ -8776,14 +9697,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "gog" = (
-/obj/machinery/light{
-	dir = 1
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
+"gok" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/comfy/black{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/turf/open/floor/plasteel/darkred/corner,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood)
 "gpd" = (
 /obj/machinery/autolathe,
 /turf/open/floor/f13{
@@ -8796,12 +9721,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "gqF" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/closet/crate/medical,
+/obj/structure/sign/poster/prewar/poster74{
+	pixel_y = 32
 	},
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
-	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "gqG" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
@@ -8811,28 +9735,44 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/brotherhood)
 "gsU" = (
-/obj/structure/table/reinforced,
-/obj/item/flashlight/lamp,
-/obj/machinery/button/door{
-	id = "librarians1";
-	name = "Librarian's Office";
-	normaldoorcontrol = 1;
-	req_access_txt = "120";
-	specialfunctions = 4
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
-"gtG" = (
-/obj/machinery/computer/card/bos,
-/obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "twindowold"
-	},
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 9
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
 	},
-/area/f13/brotherhood/offices1st)
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
+"gtG" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/structure/barricade/bars,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood)
 "gtQ" = (
 /obj/machinery/light{
 	dir = 4
@@ -8855,29 +9795,28 @@
 	},
 /area/f13/tunnel)
 "gwL" = (
-/turf/open/floor/pod/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/brotherhood)
 "gxc" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/simple_door/bunker{
+	name = "Ceremony Room";
+	req_access_txt = "120"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 6
-	},
+/turf/open/floor/plasteel/darkpurple,
 /area/f13/brotherhood)
 "gxz" = (
-/obj/machinery/flasher/portable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 10
+/obj/structure/simple_door/bunker{
+	name = "Ceremony Room";
+	req_access_txt = "120"
 	},
-/area/f13/brotherhood/armory)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "gxO" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -8889,15 +9828,10 @@
 	},
 /area/f13/followers)
 "gxX" = (
-/obj/structure/filingcabinet,
-/obj/structure/filingcabinet{
-	pixel_x = 10
-	},
-/obj/structure/filingcabinet{
-	pixel_x = -10
-	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/machinery/workbench/advanced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "gyC" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
@@ -8916,12 +9850,17 @@
 	},
 /area/f13/tunnel/bighorn)
 "gyV" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 6
+/obj/structure/table{
+	layer = 2.9
 	},
-/area/f13/brotherhood/archives)
+/obj/item/paper_bin{
+	pixel_y = 8
+	},
+/obj/item/pen{
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "gzc" = (
 /obj/item/circuitboard/machine/sleeper,
 /obj/item/circuitboard/machine/sleeper,
@@ -8947,6 +9886,15 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/followers)
+"gAA" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "gAQ" = (
 /obj/structure/decoration/vent{
 	layer = 2.8
@@ -8973,6 +9921,14 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel/bighorn)
+"gBw" = (
+/obj/structure/simple_door/bunker/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "gCo" = (
 /obj/item/stack/ore/gold,
 /turf/open/indestructible/ground/inside/subway{
@@ -9022,50 +9978,60 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "gFh" = (
-/turf/open/floor/plasteel/vault/side{
-	dir = 4
+/obj/structure/table/wood/settler,
+/obj/item/trash/tray,
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_y = 12;
+	pixel_x = -8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood)
 "gFk" = (
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood)
+"gFV" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood)
+"gGe" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
+"gGI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/power/smes/engineering,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/brotherhood)
-"gFV" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 9
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
 /area/f13/brotherhood)
-"gGe" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superlow,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 4
-	},
-/area/f13/brotherhood/armory)
-"gGI" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal{
-	dir = 1;
-	termtag = "Business"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "gHC" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/bomb/tier1,
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "gJE" = (
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/dorms)
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "gJU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -9084,8 +10050,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "gMI" = (
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/brotherhood/medical)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/hatch{
+	name = "Backup Power";
+	req_access_txt = "120"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood)
 "gNN" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
@@ -9100,6 +10074,15 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/followers)
+"gOa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
+	},
+/area/f13/brotherhood)
 "gOh" = (
 /obj/machinery/light{
 	dir = 4
@@ -9109,18 +10092,24 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/museum)
 "gPb" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/brotherhood/reactor)
-"gQf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
+/turf/open/water,
+/area/f13/caves)
+"gPy" = (
+/obj/item/documents/syndicate/blue,
+/obj/structure/table/abductor{
+	name = "Advanced Polymer Table";
+	desc = "An advanced design made from plasma and steel alloys made by Keeper Eastlyn Dauntz."
 	},
 /turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
+"gQf" = (
+/obj/structure/chair/bench{
+	dir = 4;
+	pixel_y = 1;
+	pixel_x = 8
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "gQi" = (
 /obj/item/book/granter/crafting_recipe/gunsmith_three,
 /obj/structure/table,
@@ -9129,18 +10118,23 @@
 	},
 /area/f13/bunker)
 "gQo" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 1
+/obj/structure/table{
+	pixel_y = 6
 	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/dorms)
+/obj/item/holosign_creator/security{
+	layer = 3.1;
+	name = "Head Knight's holobarrier projector";
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "gQu" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 6
+/obj/structure/decoration/smokeold{
+	pixel_x = 32
 	},
-/area/f13/brotherhood/armory)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "gQP" = (
 /obj/structure/decoration/vent/rusty,
 /turf/closed/indestructible/f13vaultrusted{
@@ -9156,43 +10150,34 @@
 	},
 /area/f13/tunnel)
 "gSv" = (
-/turf/open/floor/plasteel/vault,
+/obj/structure/chair/bench{
+	dir = 4;
+	pixel_y = 1;
+	pixel_x = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood)
 "gTT" = (
-/obj/structure/closet/cabinet{
-	anchored = 1
+/obj/structure/simple_door/metal/barred{
+	req_one_access_txt = "120"
 	},
-/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
-/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
-/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
-/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
-/obj/item/clothing/suit/toggle/labcoat/scribecoat,
-/obj/item/clothing/suit/toggle/labcoat/scribecoat,
-/obj/item/clothing/suit/toggle/labcoat/scribecoat,
-/obj/item/clothing/suit/toggle/labcoat/scribecoat,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood/archives)
+/area/f13/brotherhood)
 "gUu" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal{
-	dir = 8;
-	pixel_y = 5;
-	termtag = "Private"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/structure/frame/machine,
+/obj/item/circuitboard/machine/ore_silo,
+/obj/item/multitool,
+/obj/item/screwdriver,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
 "gUG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/brotherhood/leisure)
+/obj/structure/sign/departments/botany,
+/turf/closed/wall/r_wall/f13/vault,
+/area/f13/brotherhood)
 "gUU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/fo13colored/Red{
@@ -9209,31 +10194,25 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "gXg" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/curtain{
-	color = "#845f58";
-	pixel_x = -32
-	},
-/obj/effect/landmark/start/f13/scribe,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 8
-	},
-/area/f13/brotherhood/archives)
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
 "gXR" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 4
+/turf/open/floor/f13{
+	icon_state = "redmark"
 	},
 /area/f13/brotherhood)
 "gXT" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "gYh" = (
 /obj/machinery/light{
 	dir = 8
@@ -9249,14 +10228,23 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
-"gYI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
+"gYC" = (
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = 31;
+	pixel_y = -1
+	},
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/turf/open/water,
+/area/f13/brotherhood)
+"gYI" = (
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood)
 "gYM" = (
@@ -9291,17 +10279,22 @@
 	},
 /area/f13/followers)
 "hbv" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
+/obj/structure/window/reinforced{
+	dir = 1;
+	icon_state = "twindowold"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/decoration/vent,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood)
 "hbN" = (
-/obj/machinery/rnd/production/circuit_imprinter,
-/turf/open/floor/plasteel/darkpurple/side,
-/area/f13/brotherhood/archives)
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "hbX" = (
 /obj/structure/campfire/barrel,
 /obj/effect/decal/cleanable/dirt,
@@ -9310,19 +10303,20 @@
 	},
 /area/f13/tunnel/bighorn)
 "hcf" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/box,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 4
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowtop"
 	},
-/area/f13/brotherhood/archives)
+/obj/structure/table{
+	layer = 2.9
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "hci" = (
-/turf/open/floor/f13{
-	icon_state = "white"
-	},
-/area/f13/brotherhood/medical)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood)
 "hey" = (
 /obj/effect/turf_decal/stripes/white/corner{
 	dir = 1
@@ -9331,6 +10325,14 @@
 	icon_state = "purplefull"
 	},
 /area/f13/followers)
+"heQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "hff" = (
 /obj/item/chair,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -9338,36 +10340,24 @@
 	},
 /area/f13/tunnel)
 "hfP" = (
-/obj/structure/bed,
-/obj/item/bedsheet/black,
-/obj/machinery/button/door{
-	id = "paladins1";
-	name = "Paladin Room 1";
-	normaldoorcontrol = 1;
-	pixel_x = 32;
-	req_access_txt = "120";
-	specialfunctions = 4
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "bcircuit1";
+	light_color = "#0076bc";
+	light_power = 3;
+	light_range = 4
 	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/dorms)
+/area/f13/brotherhood)
 "hgJ" = (
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/brotherhood/reactor)
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood)
 "hgY" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/button/door{
-	id = "Castellan2";
-	name = "Castellan Office";
-	normaldoorcontrol = 1;
-	req_access_txt = "120";
-	specialfunctions = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "hho" = (
 /obj/machinery/light{
 	dir = 8
@@ -9388,17 +10378,11 @@
 	},
 /area/f13/tunnel)
 "hjR" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Restrooms";
-	req_access_txt = "120"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "hla" = (
 /obj/structure/table/wood,
 /obj/structure/curtain{
@@ -9415,11 +10399,26 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "hnd" = (
+/obj/structure/simple_door/bunker/glass,
+/obj/structure/simple_door/bunker/glass,
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
+"hoa" = (
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "hoq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -9447,12 +10446,22 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel/bighorn)
 "hpP" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault,
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood)
 "hqe" = (
-/turf/open/floor/plasteel/darkred/corner,
-/area/f13/brotherhood/armory)
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "hqq" = (
 /mob/living/simple_animal/hostile/raider/sulphite{
 	name = "Tunnel Torturers Lieutenant"
@@ -9488,6 +10497,14 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/tunnel/bighorn)
+"hsl" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood)
 "hsz" = (
 /obj/structure/table/snooker,
 /obj/item/twohanded/baseball{
@@ -9497,9 +10514,24 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "hsV" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/structure/lattice/catwalk,
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8;
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	barefootstep = "water";
+	clawfootstep = "water";
+	desc = "Shallow water.";
+	footstep = "water";
+	heavyfootstep = "water";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "riverwater_motion";
+	name = "water"
+	},
+/area/f13/brotherhood)
 "htv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -9538,6 +10570,17 @@
 /obj/effect/spawner/lootdrop/clothing_high,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"hvw" = (
+/obj/structure/chair/sofa/corp,
+/obj/machinery/camera/autoname{
+	dir = 6;
+	name = "South Facing Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "hvy" = (
 /obj/structure/decoration/vent{
 	layer = 2.8
@@ -9567,8 +10610,20 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/darkred/side{
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
+"hxS" = (
+/obj/effect/turf_decal/stripes/red/line{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood)
 "hxY" = (
@@ -9580,11 +10635,13 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel/bighorn)
 "hyi" = (
-/obj/structure/decoration/sign{
-	desc = "The Castellan makes sure to buy what is needed for the defense of the fief. While buying what they need to assist them and the paladins in their duties.";
-	name = "The Castellan"
+/obj/structure/curtain{
+	color = "#5c131b"
 	},
-/turf/closed/wall/r_wall/f13/vault,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "hyj" = (
 /obj/structure/simple_door/metal/dirtystore,
@@ -9605,15 +10662,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "hAz" = (
-/obj/structure/rack,
-/obj/item/storage/box/handcuffs{
-	pixel_x = 3;
-	pixel_y = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/survival_pod,
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
 	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 4
-	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "hAA" = (
 /obj/structure/table/wood,
 /obj/item/kirbyplants/random,
@@ -9652,24 +10710,23 @@
 /turf/open/floor/wood/wood_common,
 /area/f13/tunnel/bighorn)
 "hDv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 4;
+	name = "light fixture"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
 "hEg" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/machinery/computer/operating/bos{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood)
 "hED" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "militarystorage2"
@@ -9677,17 +10734,46 @@
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "hFj" = (
-/obj/effect/landmark/start/f13/scribe,
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
 	dir = 8
 	},
-/area/f13/brotherhood/archives)
-"hFx" = (
-/obj/machinery/firealarm{
-	name = "INTRUDER ALERT"
+/turf/open/water,
+/area/f13/brotherhood)
+"hFn" = (
+/obj/structure/closet/secure_closet/hydroponics{
+	desc = "A locker that smells of soil.";
+	name = "gardening locker";
+	req_access = list(120)
 	},
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/brotherhood/armory)
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
+"hFx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
 "hFB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains{
@@ -9706,12 +10792,12 @@
 	},
 /area/f13/tunnel)
 "hHh" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheethos"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "hHy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
@@ -9735,14 +10821,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "hIc" = (
-/obj/machinery/door/airlock/hatch{
-	id_tag = "librarians1";
-	name = "Librarian's Office";
-	req_access_txt = "120"
-	},
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
+/area/f13/brotherhood)
 "hJD" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -9757,11 +10838,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "hLB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair{
-	dir = 4
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
-/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "hLC" = (
 /obj/structure/closet/crate/large,
@@ -9785,9 +10864,13 @@
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/tunnel/bighorn)
 "hMq" = (
-/obj/structure/rack,
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/armory)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
 "hMP" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -9795,24 +10878,20 @@
 	},
 /area/f13/tunnel)
 "hMQ" = (
-/obj/machinery/vending/clothing/bos,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/armory)
+/obj/structure/chair/booth{
+	icon_state = "booth_west_south"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
 "hMR" = (
 /obj/machinery/microwave/stove,
 /turf/open/floor/wood/wood_common,
 /area/f13/tunnel/bighorn)
 "hNm" = (
-/obj/machinery/shower{
-	pixel_y = 27
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
 	},
-/obj/structure/curtain,
-/obj/structure/decoration/vent,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood)
 "hNr" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibmid3";
@@ -9828,32 +10907,31 @@
 	},
 /area/f13/building/massfusion)
 "hOa" = (
-/obj/item/storage/bag/ore,
-/obj/item/pickaxe/drill,
-/obj/item/t_scanner/adv_mining_scanner/lesser,
-/obj/item/clothing/glasses/meson,
-/obj/structure/closet,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
+/obj/structure/bed,
+/obj/item/bedsheet/hos,
+/obj/item/toy/figure/warden{
+	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
+	name = "Head Knight Action Figure";
+	toysay = "Victory is our tradition!"
 	},
-/area/f13/brotherhood/archives)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "hOt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/darkbrown/side{
-	dir = 4
-	},
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood)
 "hOV" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Power";
-	req_access_txt = "120"
+/obj/machinery/door/window/right/directional/east{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood)
 "hPx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9867,36 +10945,92 @@
 "hQf" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/building/museum)
-"hQw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 4
+"hQj" = (
+/obj/structure/table/wood/settler,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood)
+"hQw" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1;
+	pixel_x = 9
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "hQG" = (
-/obj/structure/filingcabinet,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 10
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/machinery/reagentgrinder{
+	pixel_x = -7;
+	pixel_y = 4
 	},
-/area/f13/brotherhood/armory)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
+	},
+/area/f13/brotherhood)
+"hRv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "hSI" = (
-/obj/machinery/light{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood)
+"hTw" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault/side{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
 	},
 /area/f13/brotherhood)
 "hUj" = (
-/obj/structure/bed,
-/obj/item/bedsheet/gondola,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
+"hUw" = (
+/obj/structure/chair/stool/retro/backed{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
+"hUK" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "QMLoad"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/fence/handrail{
+	dir = 4;
+	pixel_x = -15
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/area/f13/brotherhood)
 "hUY" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -9909,36 +11043,29 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "hVT" = (
-/obj/structure/table/reinforced,
-/obj/item/flashlight/lamp,
-/obj/effect/spawner/lootdrop/f13/cash_random_high,
-/obj/machinery/button/door{
-	id = "Keeper1";
-	name = "Keeper Office";
-	normaldoorcontrol = 1;
-	req_access_txt = "120";
-	specialfunctions = 4
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6;
+	pixel_y = -3
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/brotherhood)
 "hYg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 1
-	},
+/obj/structure/bodycontainer/crematorium,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "hYq" = (
 /obj/structure/table/booth,
 /turf/open/floor/wood/wood_common,
 /area/f13/tunnel/bighorn)
 "hYB" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "hYP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9952,9 +11079,10 @@
 /area/f13/tunnel/bighorn)
 "hYQ" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault/corner{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood)
 "hZi" = (
 /obj/structure/table,
@@ -9983,11 +11111,9 @@
 	},
 /area/f13/building/massfusion)
 "ibf" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 1
-	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/dorms)
+/obj/machinery/rnd/production/circuit_imprinter,
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "ibk" = (
 /obj/structure/nest/ant{
 	max_mobs = 3
@@ -9995,22 +11121,20 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ibq" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "QMUnload"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "ibY" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 8
-	},
-/area/f13/brotherhood/archives)
+/obj/structure/table/wood/poker,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/purple,
+/area/f13/brotherhood)
 "ict" = (
 /obj/item/assembly/signaler{
 	code = 2;
@@ -10019,13 +11143,25 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "icO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 8
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
 	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/turf/open/water,
 /area/f13/brotherhood)
 "idJ" = (
 /obj/structure/sink{
@@ -10038,16 +11174,15 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel/bighorn)
 "idX" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood/archives)
+/area/f13/brotherhood)
 "ief" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "bosrec"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/bench,
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "iej" = (
@@ -10059,6 +11194,23 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"ieX" = (
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_x = 10;
+	pixel_y = 23
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_x = -9;
+	pixel_y = 21
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 16
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "ifE" = (
 /obj/item/clothing/suit/armor/f13/combatrusted,
 /obj/item/clothing/head/helmet/f13/hoodedmask,
@@ -10073,23 +11225,86 @@
 	},
 /area/f13/tunnel)
 "ihr" = (
-/obj/structure/railing{
-	dir = 10
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/camera_advanced/abductor{
+	desc = "One day, we'll get that dish working. Not today.";
+	name = "Inactive Radar Console";
+	pixel_y = 17
 	},
-/turf/closed/wall/r_wall/f13/vault,
+/obj/item/wrench/advanced{
+	pixel_x = 2
+	},
+/obj/effect/decal/cleanable/robot_debris/down,
+/obj/item/crowbar/advanced,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
+	},
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/plasteel/darkpurple,
 /area/f13/brotherhood)
 "ihv" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/building/museum)
 "iiN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
+"ije" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/machinery/door/airlock/hatch{
-	id_tag = "Castellan2";
-	name = "Castellan Office";
 	req_access_txt = "120"
 	},
-/turf/open/floor/f13,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
+"ijt" = (
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
+	},
+/obj/item/clothing/accessory/bos/elder,
+/obj/item/pda/heads/hop{
+	name = "Elder's PDA"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
+"ijY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet{
+	anchored = 1;
+	name = "formal attire closet"
+	},
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood)
 "ijZ" = (
 /obj/effect/turf_decal/stripes/white/corner,
 /turf/open/floor/f13{
@@ -10097,12 +11312,11 @@
 	},
 /area/f13/followers)
 "iko" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/east,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault/side{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/brotherhood)
 "iku" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10120,8 +11334,13 @@
 	},
 /area/f13/building/massfusion)
 "ikR" = (
-/turf/open/floor/plasteel/darkred/side{
-	dir = 10
+/obj/structure/table/wood/settler,
+/obj/item/clothing/mask/cigarette/cigar{
+	pixel_y = 6
+	},
+/obj/item/storage/fancy/cigarettes/cigars/cohiba,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood)
 "ild" = (
@@ -10137,10 +11356,14 @@
 	},
 /area/f13/tunnel)
 "imi" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 8;
+	name = "light fixture"
 	},
-/turf/open/floor/plasteel/darkred/side,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/brotherhood)
 "imJ" = (
 /obj/structure/table/wood/poker,
@@ -10151,10 +11374,16 @@
 	},
 /area/f13/tunnel)
 "imX" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhdirty_chess2"
+	},
 /area/f13/brotherhood)
 "inc" = (
 /obj/structure/chair/stool/retro/black,
@@ -10176,6 +11405,19 @@
 	},
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
+"iom" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhdirty_chess2"
+	},
+/area/f13/brotherhood)
+"ioA" = (
+/obj/structure/sign/poster/prewar/poster71,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood)
 "ioG" = (
 /turf/open/floor/plasteel/dark,
 /area/f13/building/museum)
@@ -10189,11 +11431,7 @@
 	},
 /area/f13/followers)
 "iqA" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/light,
+/turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood)
 "irs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10206,11 +11444,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/building/museum)
 "irV" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
+/obj/machinery/light/small{
 	dir = 8
 	},
-/area/f13/brotherhood/offices1st)
+/obj/structure/bookcase/random,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "isl" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -10246,19 +11485,50 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"ivn" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 4
+"iuf" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
+"ivn" = (
+/obj/structure/table/wood,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "ivJ" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel/bighorn)
+"ixe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/terminal{
+	dir = 8;
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/mug/coco{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood)
 "ixJ" = (
-/turf/open/floor/plasteel/darkred/side{
-	dir = 9
+/obj/machinery/door/airlock/grunge{
+	id_tag = "bosdorm8";
+	req_access_txt = "120"
+	},
+/turf/open/floor/f13{
+	icon_state = "purplefull"
 	},
 /area/f13/brotherhood)
 "ixS" = (
@@ -10318,38 +11588,36 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "iBq" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_x = 7;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_x = -7;
-	pixel_y = 6
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/drinks/bottle/wine{
-	pixel_x = -5;
-	pixel_y = 15
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "iBD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/building/museum)
 "iBP" = (
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 10
 	},
-/area/f13/brotherhood/armory)
+/obj/structure/closet/crate/bin,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "iBR" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/building/massfusion)
+"iCl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
+	},
+/area/f13/brotherhood)
 "iDd" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress1"
@@ -10375,11 +11643,19 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "iEP" = (
-/obj/structure/decoration/sign{
-	desc = "The Knight-Commander makes sure everything is stocked in the armory and buys anything that might be useful for the knights and paladins.";
-	name = "The Knight-Commander"
+/obj/structure/lattice/catwalk,
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	barefootstep = "water";
+	clawfootstep = "water";
+	desc = "Shallow water.";
+	footstep = "water";
+	heavyfootstep = "water";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "riverwater_motion";
+	name = "water"
 	},
-/turf/closed/wall/r_wall/f13/vault,
 /area/f13/brotherhood)
 "iFc" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -10390,76 +11666,42 @@
 	},
 /area/f13/bunker)
 "iFV" = (
-/obj/machinery/light{
-	dir = 1
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
+"iGb" = (
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 1
-	},
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
-"iGb" = (
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
-	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 8
-	},
-/area/f13/brotherhood/armory)
 "iGl" = (
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/clothing/head/f13/boscap,
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
 "iGS" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
 /area/f13/followers)
+"iHL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "iIa" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
-	},
-/area/f13/brotherhood/armory)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/brotherhood)
 "iIb" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_east_north"
@@ -10508,6 +11750,17 @@
 /obj/item/stack/sheet/prewar,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
+"iLK" = (
+/obj/machinery/conveyor/inverted,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/fence/handrail{
+	dir = 4;
+	pixel_x = -15
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
 "iLR" = (
 /obj/structure/sink{
 	dir = 4;
@@ -10519,14 +11772,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "iNk" = (
-/obj/machinery/light{
-	dir = 8
+/obj/item/papercutter,
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/effect/landmark/start/f13/initiate,
-/turf/open/floor/f13{
-	dir = 1;
-	icon_state = "rampdowntop"
-	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "iOi" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -10549,11 +11799,9 @@
 	},
 /area/f13/tunnel)
 "iOT" = (
-/obj/structure/table/glass,
-/turf/open/floor/f13{
-	icon_state = "white"
-	},
-/area/f13/brotherhood/medical)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood)
 "iPa" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowbroken"
@@ -10561,20 +11809,30 @@
 /turf/open/floor/plating,
 /area/f13/tunnel/bighorn)
 "iPf" = (
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/brotherhood/archives)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/brotherhood)
 "iPU" = (
-/obj/structure/closet/crate/bin{
-	pixel_y = 15
-	},
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 4
-	},
-/area/f13/brotherhood/archives)
+/obj/structure/sign/poster/official/safety_eye_protection,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood)
 "iQB" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
+"iRD" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/pet/dog/corgi/Lisa{
+	name = "Keeper Eastlyn"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood)
 "iRM" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/decal/cleanable/dirt,
@@ -10632,6 +11890,10 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"iUq" = (
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "iUK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -10661,35 +11923,29 @@
 	},
 /area/f13/tunnel)
 "iXJ" = (
-/obj/structure/table/reinforced,
-/obj/item/pda/heads/cmo,
-/obj/structure/window/reinforced/spawner/north{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1{
+	icon_state = "casino"
 	},
-/obj/machinery/door/window/brigdoor{
-	req_access_txt = "255"
-	},
-/obj/structure/window/reinforced/spawner/north{
-	dir = 4
-	},
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 5
-	},
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "iXN" = (
-/obj/effect/turf_decal/arrows,
-/obj/effect/turf_decal/huge{
-	dir = 1
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
+/obj/machinery/computer/rdconsole/core/bos{
+	dir = 4;
+	icon_keyboard = "terminal_key";
+	icon_screen = "terminal_on_alt";
+	icon_state = "terminal"
 	},
-/area/f13/brotherhood/archives)
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "iYm" = (
-/obj/structure/railing{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/pet/cat/Runtime{
+	name = "Knight Captain Proctor"
 	},
-/turf/closed/wall/r_wall/f13/vault,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "iYn" = (
 /obj/effect/spawner/lootdrop/low_tools,
@@ -10705,6 +11961,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
+"iZr" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/table,
+/obj/item/trash/f13/electronic/toaster/atomics,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhdirty_chess2"
+	},
+/area/f13/brotherhood)
 "iZy" = (
 /obj/structure/simple_door/dirtyglass{
 	name = "Private Pub"
@@ -10719,8 +11986,11 @@
 	},
 /area/f13/tunnel)
 "jak" = (
-/turf/open/floor/plasteel/vault/side{
-	dir = 9
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood)
 "jaC" = (
@@ -10736,6 +12006,12 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"jbj" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/belt,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "jbv" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -10743,11 +12019,14 @@
 	},
 /area/f13/tunnel)
 "jbz" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 9
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/area/f13/brotherhood/armory)
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "jbA" = (
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
@@ -10763,15 +12042,18 @@
 	},
 /area/f13/tunnel)
 "jbR" = (
-/obj/structure/chair/bench,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
+"jbY" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood)
 "jcp" = (
 /obj/machinery/light{
 	dir = 4
@@ -10786,27 +12068,27 @@
 	},
 /area/f13/followers)
 "jdz" = (
-/obj/structure/bed,
-/obj/item/bedsheet/grey,
-/obj/effect/landmark/start/f13/seniorknight,
-/obj/item/toy/plush/beeplushie,
+/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
+	},
+/area/f13/brotherhood)
 "jdR" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "jdX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sink/kitchen{
-	dir = 4;
-	pixel_x = -12
+/obj/structure/fence/handrail{
+	density = 0;
+	layer = 4.1;
+	pixel_x = 4;
+	pixel_y = -16
 	},
-/turf/open/floor/f13{
-	icon_state = "white"
-	},
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/carpet,
+/area/f13/brotherhood)
 "jek" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 10
@@ -10823,18 +12105,24 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/tunnel)
 "jfa" = (
+/obj/machinery/rnd/destructive_analyzer,
+/obj/machinery/light/fo13colored/Aqua{
+	brightness = 3;
+	critical_machine = 1;
+	dir = 8;
+	flicker_chance = 0;
+	icon_state = "bulb";
+	name = "Light Bulb"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "jfH" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood)
 "jgU" = (
 /obj/structure/barricade/wooden/planks,
 /turf/closed/wall/rust,
@@ -10854,44 +12142,57 @@
 	},
 /area/f13/followers)
 "jiV" = (
-/obj/structure/curtain{
-	color = "#845f58";
-	pixel_x = -32
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/effect/landmark/start/f13/scribe,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 8
-	},
-/area/f13/brotherhood/archives)
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/brotherhood)
 "jjj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel/bighorn)
 "jju" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall/f13/vault,
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/decoration/vent,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood)
+"jjV" = (
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/darkpurple,
 /area/f13/brotherhood)
 "jkr" = (
-/obj/structure/chair{
-	dir = 1
+/obj/structure/chair/sofa/corp{
+	dir = 8
 	},
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_y = 32
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
 /area/f13/brotherhood)
 "jkI" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowtop"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/brotherhood)
+"jlT" = (
+/obj/item/kirbyplants/photosynthetic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "jmo" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10900,15 +12201,14 @@
 	},
 /area/f13/tunnel)
 "jng" = (
-/obj/structure/table/glass,
-/obj/item/toy/plush/beeplushie{
-	name = "Keeper Fuzzybutt"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "white"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood)
 "jnH" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -10921,10 +12221,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel/bighorn)
 "jov" = (
-/obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "jpy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -10941,18 +12242,20 @@
 	},
 /area/f13/followers)
 "jpP" = (
-/obj/machinery/light,
+/obj/machinery/door/airlock/hatch{
+	name = "Security Checkpoint";
+	req_access_txt = "120"
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/f13{
-	icon_state = "white"
-	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood)
 "jpS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
+	},
+/area/f13/brotherhood)
 "jqi" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
 	icon_state = "neutralrusty"
@@ -10965,13 +12268,54 @@
 	},
 /area/f13/building/massfusion)
 "jqz" = (
-/obj/effect/turf_decal/box,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
+/obj/structure/lattice{
+	layer = 3
 	},
-/obj/structure/closet/crate/wooden,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/shuttle_manipulator{
+	desc = "You have no idea what this shows.";
+	name = "old hologram";
+	pixel_x = 16;
+	pixel_y = -16
+	},
+/obj/machinery/shuttle_manipulator{
+	desc = "You have no idea what this shows.";
+	icon_state = "hologram_ship";
+	name = "old hologram";
+	pixel_x = 14;
+	pixel_y = 9
+	},
+/obj/machinery/shuttle_manipulator{
+	desc = "You have no idea what this shows.";
+	icon_state = "hologram_on";
+	name = "old hologram";
+	pixel_x = 16;
+	pixel_y = 1
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
+"jqN" = (
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fence/handrail_corner{
+	density = 0;
+	dir = 1;
+	layer = 3.1;
+	pixel_x = -12;
+	pixel_y = -9
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 1;
+	pixel_y = -9
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "jre" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10984,12 +12328,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "jrv" = (
-/obj/structure/bed,
-/obj/item/bedsheet/grey,
-/obj/effect/landmark/start/f13/seniorpaladin,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
+	},
+/obj/machinery/mineral/equipment_vendor,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/brotherhood)
 "jsj" = (
 /obj/structure/closet/secure_closet/goodies{
 	anchorable = 0;
@@ -11024,6 +12370,16 @@
 /obj/item/clothing/head/hardhat,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/museum)
+"jtQ" = (
+/obj/item/pen/fountain/captain{
+	name = "elder's fountain pen"
+	},
+/obj/structure/table/abductor{
+	name = "Advanced Polymer Table";
+	desc = "An advanced design made from plasma and steel alloys made by Keeper Eastlyn Dauntz."
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "jtZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkpurple/side{
@@ -11055,22 +12411,56 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel/bighorn)
+"jwf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/carpet,
+/area/f13/brotherhood)
 "jwv" = (
-/obj/machinery/mineral/wasteland_trader,
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
+"jwC" = (
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/turf/open/water,
 /area/f13/brotherhood)
 "jxe" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal{
-	dir = 8;
-	pixel_y = 3;
-	termtag = "Security"
+/obj/structure/simple_door/bunker{
+	name = "Ceremony Room";
+	req_access_txt = "120"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "jxG" = (
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "jxX" = (
 /obj/structure/chair{
 	dir = 1
@@ -11106,6 +12496,27 @@
 /obj/item/reagent_containers/food/drinks/bottle/brown/greenwine,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/tunnel/bighorn)
+"jAK" = (
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	dir = 5;
+	name = "Reactor Camera";
+	network = list("BoS")
+	},
+/turf/open/water,
+/area/f13/brotherhood)
 "jBB" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks{
@@ -11117,12 +12528,15 @@
 	},
 /area/f13/tunnel)
 "jCu" = (
-/obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
+/obj/machinery/door/airlock/grunge{
+	id_tag = null;
+	req_access_txt = "120"
 	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood)
 "jCv" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -11159,25 +12573,49 @@
 	},
 /area/f13/tunnel)
 "jGM" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "white"
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
 	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
+"jGW" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/paper_bin{
+	pixel_y = 5
+	},
+/obj/item/pen{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "jHm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/food/drinks/flask/vault13,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building/museum)
 "jHx" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "white"
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/ausbushes/grassybush{
+	layer = 2.1
 	},
-/area/f13/brotherhood/medical)
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 8
+	},
+/turf/open/water,
+/area/f13/brotherhood)
 "jHV" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars,
@@ -11204,12 +12642,15 @@
 	},
 /area/f13/tunnel)
 "jKl" = (
-/obj/machinery/iv_drip,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "white"
+/obj/machinery/door/airlock/grunge{
+	name = "Castellan's Office";
+	req_access_txt = "120"
 	},
-/area/f13/brotherhood/medical)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "jKJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -11238,10 +12679,8 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "jOo" = (
-/obj/item/flag/bos{
-	density = 0
-	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "jOv" = (
 /obj/effect/turf_decal/stripes/white/line,
@@ -11250,9 +12689,20 @@
 	},
 /area/f13/followers)
 "jOM" = (
+/obj/machinery/computer/secure_data{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
+"jPL" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/autolathe,
+/obj/effect/turf_decal/stripes/box,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault/side{
-	dir = 9
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood)
 "jRd" = (
@@ -11265,15 +12715,13 @@
 	},
 /area/f13/building/massfusion)
 "jRx" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Meeting Room";
-	req_access_txt = "120"
-	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood)
 "jRz" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
@@ -11298,29 +12746,24 @@
 	},
 /area/f13/tunnel)
 "jUU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/brotherhood/leisure)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "jVE" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal{
-	pixel_y = 4
-	},
+/obj/item/flag/bos,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 9
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood)
 "jVN" = (
-/obj/structure/simple_door/metal/vaultreinforced{
-	icon_state = "vaultrwall3"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/comfy/black{
+	dir = 8
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood)
 "jWf" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -11328,27 +12771,40 @@
 	},
 /area/f13/tunnel)
 "jWs" = (
-/obj/structure/chair,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/caution{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood)
 "jWy" = (
 /obj/structure/decoration/warning,
 /turf/closed/wall/rust,
 /area/f13/tunnel/bighorn)
+"jYk" = (
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "jYv" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "jZb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/door/airlock/grunge{
+	id_tag = null;
+	req_access_txt = "120"
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/conveyor/inverted{
-	dir = 10;
-	id = "QMUnload"
-	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "jZC" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
@@ -11361,10 +12817,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "kaf" = (
-/obj/structure/chair/sofa/corp,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/dorms)
+/obj/structure/chair/sofa/corp/left,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "kau" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -11372,22 +12829,32 @@
 	},
 /area/f13/tunnel/bighorn)
 "kaX" = (
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/dorms)
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/turf/open/water,
+/area/f13/brotherhood)
 "kbd" = (
-/turf/closed/indestructible/vaultdoor{
-	desc = "A wall built to withstand an atomic explosion.";
-	icon = 'icons/fallout/turfs/walls/vault_reinforced.dmi';
-	icon_state = "vaultrwall0";
-	icon_type_smooth = "vaultrwall";
-	name = "vault reinforced wall"
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/area/f13/brotherhood/medical)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "kcm" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -11400,29 +12867,27 @@
 	},
 /area/f13/building/massfusion)
 "kcP" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/indestructible/vaultdoor{
-	desc = "A wall built to withstand an atomic explosion.";
-	icon = 'icons/fallout/turfs/walls/vault_reinforced.dmi';
-	icon_state = "vaultrwall0";
-	icon_type_smooth = "vaultrwall";
-	name = "vault reinforced wall"
+/obj/structure/fence/corner{
+	dir = 8
 	},
-/area/f13/brotherhood/reactor)
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8;
+	pixel_x = 8
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "kdI" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/caves)
 "kdZ" = (
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/darkred/side,
+/turf/open/water,
 /area/f13/brotherhood)
 "keE" = (
 /obj/structure/wreck/trash/halftire,
@@ -11469,6 +12934,16 @@
 /obj/item/clothing/under/f13/raiderharness,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"khl" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
 "kib" = (
 /turf/open/floor/plasteel/stairs{
 	color = "#4b3a26";
@@ -11489,12 +12964,16 @@
 	},
 /area/f13/tunnel)
 "kjN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/door/airlock/hatch{
+	id_tag = "Keeper2";
+	name = "Keeper's Room";
+	req_access_txt = "120"
 	},
-/obj/item/multitool,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/brotherhood/reactor)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "kjY" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
@@ -11523,11 +13002,16 @@
 	},
 /area/f13/building/massfusion)
 "knT" = (
-/obj/structure/chair{
-	dir = 1
+/obj/structure/lattice{
+	density = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fluff/railing{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "kov" = (
 /obj/item/storage/trash_stack,
@@ -11550,25 +13034,15 @@
 	},
 /area/f13/building/massfusion)
 "krl" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 5;
-	height = 7;
-	id = "supply_home";
-	name = "Cargo Bay";
-	width = 12
+/obj/effect/turf_decal/caution{
+	dir = 4
 	},
-/turf/open/floor/pod/light,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/brotherhood)
 "krv" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal{
-	dir = 8;
-	termtag = "Secret"
-	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 5
-	},
+/obj/machinery/vending/wardrobe/engi_wardrobe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood)
 "ksh" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -11580,14 +13054,11 @@
 	},
 /area/f13/tunnel)
 "ktb" = (
-/obj/machinery/door/window/right{
-	dir = 4;
-	req_one_access_txt = "120"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 4
-	},
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "kth" = (
 /obj/structure/nest/molerat{
 	max_mobs = 1
@@ -11626,6 +13097,13 @@
 /obj/machinery/autolathe/ammo,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
+"kwH" = (
+/obj/machinery/flasher/portable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood)
 "kyo" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
@@ -11634,11 +13112,12 @@
 	},
 /area/f13/tunnel)
 "kze" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/item/papercutter,
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "kzp" = (
 /obj/item/stack/ore/gold,
 /obj/item/stack/ore/gold,
@@ -11648,11 +13127,16 @@
 	},
 /area/f13/caves)
 "kzw" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
 	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood)
 "kzT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -11695,6 +13179,14 @@
 /obj/structure/timeddoor,
 /turf/closed/wall/r_wall/rust,
 /area/f13/tunnel)
+"kDq" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood)
 "kDy" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -11713,6 +13205,11 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
+"kEi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/flag/bos,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "kEq" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -11728,12 +13225,13 @@
 	},
 /area/f13/tunnel)
 "kFP" = (
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowright"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood)
 "kFT" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -11742,22 +13240,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "kHa" = (
-/obj/machinery/light{
+/obj/structure/chair/office/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "kHC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/turf/open/floor/f13{
-	icon_state = "white"
-	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood)
 "kIO" = (
 /obj/structure/closet/crate/large,
 /obj/effect/spawner/lootdrop/f13/blueprintLow,
@@ -11783,19 +13278,19 @@
 /turf/open/floor/plating,
 /area/f13/building/museum)
 "kJP" = (
-/obj/structure/punching_bag{
-	pixel_y = 6
+/obj/structure/chair/bench{
+	dir = 4;
+	pixel_y = 1;
+	pixel_x = -7
 	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/dorms)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "kKh" = (
-/obj/machinery/door/airlock/hatch{
-	id_tag = "knightc2";
-	name = "Knight-Commander Office";
-	req_access_txt = "120"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
 "kKi" = (
 /obj/structure/table/glass,
 /obj/item/storage/firstaid,
@@ -11811,17 +13306,14 @@
 	},
 /area/f13/tunnel)
 "kKT" = (
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/clothing/head/f13/boscap,
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "kMc" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-06"
@@ -11837,11 +13329,14 @@
 	},
 /area/f13/tunnel)
 "kNk" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/machinery/light/floor,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "kNM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/shoes/f13/raidertreads,
@@ -11867,35 +13362,46 @@
 	},
 /area/f13/caves)
 "kRz" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/structure/rack,
+/obj/item/book/granter/trait/pa_wear,
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
+"kRQ" = (
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_x = 8
+	},
+/obj/machinery/deepfryer,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhdirty_chess2"
+	},
+/area/f13/brotherhood)
+"kRS" = (
+/obj/machinery/computer/med_data{
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/brotherhood)
-"kRQ" = (
-/obj/machinery/button/door{
-	id = "BOSPAS";
-	name = "Power Armor Storage Button";
-	req_access_txt = "255"
-	},
-/turf/closed/indestructible/vaultdoor{
-	desc = "A wall built to withstand an atomic explosion.";
-	icon = 'icons/fallout/turfs/walls/vault_reinforced.dmi';
-	icon_state = "vaultrwall0";
-	icon_type_smooth = "vaultrwall";
-	name = "vault reinforced wall"
-	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "kSu" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/area/f13/brotherhood/armory)
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "kTc" = (
 /obj/effect/spawner/lootdrop/crafts,
 /obj/effect/overlay/junk/oldpipes{
@@ -11903,6 +13409,12 @@
 	},
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
+"kTN" = (
+/obj/machinery/chem_master/condimaster,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/brotherhood)
 "kTX" = (
 /obj/structure/nest/gecko{
 	max_mobs = 2
@@ -11910,18 +13422,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "kUa" = (
-/obj/structure/rack,
-/obj/item/clothing/head/bomb_hood/security,
-/obj/item/clothing/suit/bomb_suit/security,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
-	},
-/area/f13/brotherhood/armory)
+/obj/structure/table/wood,
+/obj/item/pizzabox/mushroom,
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
 "kUs" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/offices1st)
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowright"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/brotherhood)
 "kUu" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -11978,12 +13488,14 @@
 	},
 /area/f13/building/massfusion)
 "kWr" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 4
+/obj/machinery/workbench/bottler,
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
 	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/brotherhood)
 "kWM" = (
 /obj/structure/table/wood/settler,
 /obj/item/gun/ballistic/revolver/caravan_shotgun,
@@ -12011,14 +13523,29 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"laf" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Armory";
-	req_access_txt = "120"
+"kZu" = (
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/armory)
+/obj/machinery/mineral/wasteland_vendor/weapons/BoS,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/area/f13/brotherhood)
+"laf" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 6;
+	name = "South Facing Camera";
+	network = list("BoS")
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
 "lao" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -12028,12 +13555,17 @@
 	},
 /area/f13/tunnel/bighorn)
 "laA" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/rack,
+/obj/item/clothing/suit/bomb_suit/security,
+/obj/item/clothing/head/bomb_hood/security,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
 	},
-/obj/structure/chair/sofa/corp/corner,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "laM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12055,18 +13587,24 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "lcf" = (
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/window/reinforced/spawner/north,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault/side{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood)
 "lcx" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/darkpurple/side,
-/area/f13/brotherhood/archives)
+/obj/machinery/microwave/stove,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhdirty_chess2"
+	},
+/area/f13/brotherhood)
 "lcO" = (
 /obj/structure/table/booth,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -12077,6 +13615,11 @@
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
+"ldj" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/burger/bigbite,
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
 "ldo" = (
 /obj/item/trash/f13/dog,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -12095,13 +13638,8 @@
 	},
 /area/f13/tunnel/bighorn)
 "ldv" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "lex" = (
 /obj/structure/barricade/bars{
 	layer = 5
@@ -12110,32 +13648,35 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "leW" = (
-/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "lfq" = (
-/obj/structure/ore_box,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/structure/curtain{
+	color = "#5c131b"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
+	},
 /area/f13/brotherhood)
 "lfB" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/building/massfusion)
 "lgh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "knightc2";
-	name = "Knight-commanders office";
-	normaldoorcontrol = 1;
-	pixel_x = -32;
-	req_access_txt = "120";
-	specialfunctions = 4
+/obj/item/toy/figure/chemist{
+	layer = 2.8;
+	name = "Scribe action figure";
+	toysay = "Ad meliora."
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/machinery/chem_dispenser,
+/obj/structure/sign/poster/prewar/poster74{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "lgJ" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -12149,15 +13690,12 @@
 	},
 /area/f13/brotherhood)
 "lhi" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/fence,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8;
+	pixel_x = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 4
-	},
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood)
 "lht" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -12174,9 +13712,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "lii" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "ljp" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/stack/sheet/plastic/fifty,
@@ -12186,11 +13729,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "ljv" = (
-/obj/effect/spawner/structure/window/plastitanium,
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/turf/open/water,
 /area/f13/brotherhood)
 "ljB" = (
 /obj/effect/decal/remains{
@@ -12201,12 +13746,20 @@
 	},
 /area/f13/tunnel)
 "llc" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/fence,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4;
+	pixel_x = -7
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
+"lld" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
 /turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "llt" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -12218,19 +13771,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/building/museum)
 "lmq" = (
-/obj/machinery/button/door{
-	id = "Keeper2";
-	name = "Keeper Room";
-	normaldoorcontrol = 1;
-	pixel_x = 32;
-	req_access_txt = "120";
-	specialfunctions = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/light{
-	dir = 4
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "lms" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/f13{
@@ -12238,23 +13786,25 @@
 	},
 /area/f13/tunnel)
 "lmM" = (
-/obj/machinery/button/door{
-	id = "scribes1";
-	name = "Scribe Room 1";
-	normaldoorcontrol = 1;
-	pixel_x = 32;
-	req_access_txt = "120";
-	specialfunctions = 4
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowright"
 	},
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/dorms)
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "lmN" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "lnb" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/medsprays,
@@ -12266,8 +13816,9 @@
 	},
 /area/f13/followers)
 "lnh" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/mre,
+/obj/structure/bookcase/manuals/medical,
+/obj/item/hand_labeler,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "lnB" = (
@@ -12278,15 +13829,16 @@
 	},
 /area/f13/tunnel)
 "lnQ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/recharge_station,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
+"loz" = (
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	desc = "A console that is capable of accessing the whole of the Brotherhood of Steel's archives. A very important aspect of their organization, this machine is not to be tampered with. Unless sabotage is your goal.";
+	name = "archive database"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/darkbrown/side{
-	dir = 4
-	},
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/darkpurple,
 /area/f13/brotherhood)
 "loE" = (
 /obj/machinery/light{
@@ -12316,9 +13868,13 @@
 	},
 /area/f13/tunnel/bighorn)
 "lpl" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/dorms)
+/obj/machinery/vending/hydronutrients{
+	force_free = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "lpo" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/handrail/g_central{
@@ -12339,11 +13895,11 @@
 	},
 /area/f13/building/massfusion)
 "lpA" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood)
 "lpF" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/decal/cleanable/dirt,
@@ -12362,11 +13918,9 @@
 /turf/open/floor/plasteel/darkpurple/side,
 /area/f13/building/museum)
 "lqS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/toilet{
-	dir = 4
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
 	},
-/turf/open/floor/mineral/plastitanium,
 /area/f13/brotherhood)
 "lrO" = (
 /obj/structure/simple_door/metal/dirtystore,
@@ -12385,21 +13939,21 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/camera/autoname{
+	dir = 6;
+	name = "South Facing Camera";
+	network = list("BoS")
+	},
 /turf/open/floor/plasteel/darkred/side{
 	dir = 5
 	},
 /area/f13/brotherhood)
 "ltf" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/lattice{
+	layer = 3
 	},
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "ltk" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -12446,11 +14000,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/building/museum)
 "lvS" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/bench,
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "lwl" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/minigunpack,
@@ -12460,6 +14014,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/building/museum)
+"lyJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
 "lAI" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
@@ -12468,27 +14031,22 @@
 	},
 /area/f13/tunnel)
 "lAN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/offduty,
-/turf/open/floor/plasteel/vault/side{
-	dir = 6
+/obj/machinery/light/small,
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = -32
 	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "lBb" = (
-/obj/structure/ore_box,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
+/turf/closed/mineral/random/high_chance,
 /area/f13/brotherhood)
 "lBs" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Head Scribe Office";
-	req_access_txt = "120"
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
 	},
-/turf/open/floor/plasteel/darkpurple,
-/area/f13/brotherhood/archives)
+/area/f13/brotherhood)
 "lBD" = (
 /obj/machinery/light{
 	dir = 1
@@ -12503,17 +14061,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/museum)
 "lCI" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal{
-	dir = 8;
-	termtag = "Secret"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/brotherhood)
 "lDl" = (
 /obj/machinery/door/poddoor/shutters{
@@ -12556,14 +14105,14 @@
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "lEP" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/camera/autoname{
+	dir = 8;
+	name = "Armory Camera";
+	network = list("BoS");
+	pixel_x = -1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "white"
-	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/darkred/side,
+/area/f13/brotherhood)
 "lER" = (
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/subway{
@@ -12571,9 +14120,46 @@
 	},
 /area/f13/caves)
 "lEW" = (
-/obj/structure/sign/departments/medbay/alt,
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/brotherhood/medical)
+/obj/item/am_containment{
+	pixel_x = 3
+	},
+/obj/structure/table/reinforced,
+/obj/structure/window/plasma/reinforced{
+	dir = 4
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 8
+	},
+/obj/structure/window/plasma/reinforced,
+/obj/machinery/door/window/brigdoor{
+	dir = 1
+	},
+/obj/item/am_containment,
+/obj/item/am_containment{
+	pixel_x = -3
+	},
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 5;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood)
 "lEZ" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
@@ -12591,13 +14177,23 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/tunnel)
-"lIt" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 10
+"lIj" = (
+/obj/structure/chair/booth{
+	icon_state = "booth_west_south"
 	},
-/area/f13/brotherhood/archives)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
+"lIt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "lIv" = (
 /obj/structure/sign/poster/official/soft_cap_pop_art{
 	pixel_y = 32
@@ -12653,6 +14249,13 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"lNq" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/circuitboard/machine/chem_master/advanced,
+/obj/item/circuitboard/machine/sleeper/syndie,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "lNx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -12691,14 +14294,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "lOD" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
 	},
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_x = -32
+/obj/item/integrated_circuit_printer{
+	pixel_y = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "lOZ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -12712,14 +14315,24 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "lPd" = (
-/obj/machinery/photocopier,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side,
-/area/f13/brotherhood/armory)
+/obj/structure/table/wood/poker,
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood)
 "lPe" = (
-/obj/effect/landmark/start/f13/Knight,
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/armory)
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "lPo" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -12734,14 +14347,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "lQa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/decal/cleanable/oil,
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/obj/machinery/conveyor{
-	dir = 9;
-	id = "QMLoad"
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "lQx" = (
 /obj/structure/rack/shelf_metal,
@@ -12805,15 +14417,13 @@
 	},
 /area/f13/caves)
 "lTk" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/rnd/server/bos,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 8
-	},
-/area/f13/brotherhood/archives)
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "lTr" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "rampdowntop"
@@ -12954,9 +14564,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "maB" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/circuitboard/machine/cyborgrecharger,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1;
+	pixel_y = -1
+	},
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/brotherhood)
 "maO" = (
 /obj/machinery/light{
@@ -12985,10 +14602,12 @@
 /area/f13/tunnel)
 "mco" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 4
+/obj/effect/landmark/start/f13/Knight,
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
 	},
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood)
 "mcX" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -12999,13 +14618,14 @@
 	},
 /area/f13/building/massfusion)
 "mdo" = (
-/obj/machinery/door/airlock/hatch{
-	id_tag = "paladins1";
-	name = "Paladin Room 1";
-	req_access_txt = "120"
+/obj/structure/bookcase/manuals/engineering{
+	desc = "A collection of scrolls, archives and relics.";
+	name = "Brotherhood Archives"
 	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood)
 "mdL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -13017,34 +14637,55 @@
 /turf/closed/wall/rust,
 /area/f13/tunnel)
 "mfA" = (
-/obj/structure/filingcabinet/chestdrawer/wheeled,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
+"mfI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "mfT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
 /area/f13/tunnel)
+"mfU" = (
+/obj/structure/closet{
+	anchored = 1;
+	name = "formal attire closet"
+	},
+/obj/item/clothing/under/f13/bosform_m,
+/obj/item/clothing/under/f13/bosform_m,
+/obj/item/clothing/under/f13/bosform_m,
+/obj/item/clothing/under/f13/bosform_f,
+/obj/item/clothing/under/f13/bosform_f,
+/obj/item/clothing/under/f13/bosform_f,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood)
 "mib" = (
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/structure/closet/crate{
-	anchored = 1
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/item/gun/energy/laser/practice,
-/obj/item/gun/energy/laser/practice,
-/obj/item/gun/energy/laser/practice,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/corner{
-	dir = 4
+/obj/machinery/camera/autoname{
+	dir = 6;
+	name = "South Facing Camera";
+	network = list("BoS")
 	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood)
 "mix" = (
 /obj/structure/wreck/trash/four_barrels,
 /obj/effect/turf_decal/weather/dirt{
@@ -13058,33 +14699,40 @@
 	},
 /area/f13/building/massfusion)
 "mjl" = (
-/obj/structure/curtain{
-	pixel_y = -32
+/obj/structure/fence/corner,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4;
+	pixel_x = -7
 	},
-/obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/med/surgery{
-	pixel_y = 8
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
+"mlg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	layer = 2.9
 	},
-/obj/item/clothing/gloves/color/latex/nitrile,
-/turf/open/floor/plasteel/freezer,
-/area/f13/brotherhood/medical)
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "mlD" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
-"mme" = (
 /obj/structure/window/reinforced{
+	color = "#3e3d42";
 	dir = 1;
-	icon_state = "twindowold"
+	layer = 3.1
 	},
-/obj/structure/rack,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
-	},
-/area/f13/brotherhood/offices1st)
+/obj/machinery/light/small,
+/turf/open/water,
+/area/f13/brotherhood)
+"mme" = (
+/obj/structure/dresser,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "mms" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks,
@@ -13097,9 +14745,12 @@
 /turf/closed/wall/rust,
 /area/f13/tunnel)
 "mng" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/circuitboard/machine/medipen_refiller,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/obj/structure/chair/bench{
+	dir = 4;
+	pixel_y = 1;
+	pixel_x = -7
+	},
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood)
 "mnp" = (
 /obj/machinery/smartfridge/chemistry/preloaded{
@@ -13125,34 +14776,37 @@
 	},
 /area/f13/tunnel)
 "mpk" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault/side{
-	dir = 1
+/turf/open/floor/f13{
+	icon_state = "redmark"
 	},
 /area/f13/brotherhood)
 "mpp" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 8
-	},
-/area/f13/brotherhood/armory)
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
 "mqg" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/brigdoor{
-	dir = 4;
-	req_access_txt = "255"
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/effect/spawner/lootdrop/f13/armor/bos_vault,
-/turf/open/floor/plasteel/vault/side{
-	dir = 4
+/obj/item/encryptionkey/headset_bos{
+	pixel_x = -8
 	},
+/obj/item/encryptionkey/headset_bos{
+	pixel_x = -8
+	},
+/obj/item/encryptionkey/headset_bos{
+	pixel_x = -8
+	},
+/obj/item/card/id/dogtag{
+	pixel_x = 4
+	},
+/obj/item/card/id/dogtag{
+	pixel_x = 4
+	},
+/obj/item/card/id/dogtag{
+	pixel_x = 4
+	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "mrm" = (
 /obj/machinery/shower{
@@ -13165,19 +14819,38 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"msk" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/machinery/light/small{
-	dir = 8
+"msi" = (
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
+"msk" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Security Checkpoint";
+	req_access_txt = "120"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood)
 "mst" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/darkpurple,
-/area/f13/brotherhood/archives)
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
+"msJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "msT" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/turf_decal/weather/dirt{
@@ -13190,14 +14863,11 @@
 	},
 /area/f13/building/massfusion)
 "msW" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal{
-	pixel_y = 3;
-	termtag = "Security"
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "mtl" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkred/side,
@@ -13228,17 +14898,8 @@
 	},
 /area/f13/followers)
 "mwb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "librarians2";
-	name = "Librarian's Room";
-	normaldoorcontrol = 1;
-	pixel_x = -32;
-	req_access_txt = "120";
-	specialfunctions = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/carpet/purple,
+/area/f13/brotherhood)
 "mwc" = (
 /obj/structure/chair/middle{
 	dir = 4
@@ -13252,6 +14913,15 @@
 /obj/structure/junk/small/tv,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel/bighorn)
+"myg" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
 "myk" = (
 /obj/machinery/light{
 	dir = 4
@@ -13262,16 +14932,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/followers)
 "myl" = (
-/obj/structure/table/wood,
-/obj/machinery/button/door{
-	id = "Baron1";
-	name = "Baron Office";
-	normaldoorcontrol = 1;
-	req_access_txt = "120";
-	specialfunctions = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4;
+	pixel_x = -7
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "myu" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
@@ -13294,6 +14962,17 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"mAW" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "mBv" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -13318,14 +14997,13 @@
 	},
 /area/f13/tunnel)
 "mDf" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/machinery/autolathe/ammo/unlocked,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood)
 "mDz" = (
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/floor/f13/wood,
@@ -13344,22 +15022,63 @@
 /area/f13/tunnel)
 "mEL" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "mER" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/followers)
+"mFx" = (
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1
+	},
+/turf/open/water,
+/area/f13/brotherhood)
+"mGk" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/sign/poster/contraband/tools{
+	pixel_y = 31
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood)
 "mGm" = (
 /obj/structure/fluff/destroyed_nuclear_reactor,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building/massfusion)
-"mIf" = (
-/turf/open/floor/plasteel/darkred/side{
-	dir = 8
+"mHK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
+"mIf" = (
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "mIM" = (
 /obj/machinery/workbench/mbench,
@@ -13378,7 +15097,23 @@
 	},
 /area/f13/tunnel)
 "mKl" = (
-/turf/open/floor/plasteel/vault/side,
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/turf/open/water,
 /area/f13/brotherhood)
 "mKX" = (
 /obj/structure/barricade/bars,
@@ -13387,35 +15122,43 @@
 	},
 /area/f13/tunnel)
 "mLk" = (
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fireaxecabinet{
+	pixel_x = 33
+	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "mLD" = (
-/obj/machinery/conveyor{
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/storage/firstaid/regular{
+	pixel_y = 5
+	},
+/obj/item/storage/firstaid/regular,
+/obj/machinery/light/small{
+	brightness = 3;
 	dir = 8;
-	id = "QMLoad"
+	pixel_y = 10
 	},
-/obj/machinery/light,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "mMU" = (
+/obj/machinery/light/floor,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/toilet{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/light/small{
-	dir = 8
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/floor/mineral/plastitanium,
 /area/f13/brotherhood)
 "mNr" = (
 /obj/structure/toilet{
@@ -13424,18 +15167,12 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel/bighorn)
 "mNH" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "QMLoad"
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/obj/structure/closet/crate/science,
-/obj/machinery/status_display/supply{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "mPA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13444,19 +15181,26 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building/museum)
 "mPJ" = (
+/obj/structure/chair/bench,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "mQC" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/hatch{
-	name = "Holding Cells";
-	req_access_txt = "120"
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = 32
+	},
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_y = 5
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood)
 "mRt" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -13487,14 +15231,11 @@
 	},
 /area/f13/caves)
 "mTy" = (
-/turf/closed/indestructible/vaultdoor{
-	desc = "A wall built to withstand an atomic explosion.";
-	icon = 'icons/fallout/turfs/walls/vault_reinforced.dmi';
-	icon_state = "vaultrwall0";
-	icon_type_smooth = "vaultrwall";
-	name = "vault reinforced wall"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "mTL" = (
 /obj/effect/decal/waste,
 /obj/structure/closet/cabinet,
@@ -13504,18 +15245,47 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "mVc" = (
-/obj/structure/chair/comfy/black,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/grunge{
+	name = "Knight Commander's Office";
+	req_access_txt = "120"
+	},
+/obj/machinery/door/airlock/grunge{
+	name = "Knight Commander's Office";
+	req_access_txt = "120"
+	},
+/turf/open/water,
+/area/f13/brotherhood)
 "mVE" = (
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "mWI" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/door/airlock/grunge{
+	id_tag = "headscribedorm";
+	name = "Head Scribe's Office";
+	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
 /area/f13/brotherhood)
 "mWL" = (
@@ -13533,13 +15303,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/building/museum)
 "mWZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
 	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 8
+/obj/structure/mirror{
+	pixel_x = 30
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood)
 "mYn" = (
 /obj/structure/flora/wasteplant/wild_punga,
@@ -13559,12 +15330,14 @@
 	},
 /area/f13/tunnel)
 "nbJ" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/syndicatebomb/self_destruct,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood)
 "ndM" = (
 /obj/structure/chair/right,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
@@ -13604,20 +15377,21 @@
 	},
 /area/f13/tunnel)
 "nfe" = (
-/obj/effect/turf_decal/caution{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/box,
+/obj/structure/closet/crate,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/brotherhood)
 "nfk" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "QMLoad"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
+"nho" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhdirty_chess2"
 	},
-/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "nhJ" = (
 /obj/structure/table/wood,
@@ -13636,14 +15410,18 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "niT" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/table/wood/settler,
+/obj/item/trash/tray,
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_y = 12;
+	pixel_x = -8
 	},
-/obj/machinery/radioterminal/bos{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "niW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/asteroid/line,
@@ -13679,13 +15457,9 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "nnk" = (
-/obj/effect/turf_decal/caution{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/box,
+/obj/machinery/recycler,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/brotherhood)
 "nnA" = (
 /obj/machinery/door/airlock/medical{
@@ -13722,14 +15496,22 @@
 	},
 /area/f13/tunnel)
 "npF" = (
-/obj/structure/table/glass,
-/obj/item/flashlight/lamp,
-/obj/structure/window/reinforced{
+/obj/machinery/button/door{
+	id = "headscribedorm";
+	normaldoorcontrol = 1;
+	pixel_x = -8;
+	pixel_y = -24;
+	specialfunctions = 4
+	},
+/obj/structure/chair/sofa/corp/corner{
 	dir = 8
 	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/archives)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood)
 "nqd" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -13741,22 +15523,18 @@
 	},
 /area/f13/tunnel)
 "nqe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
+/obj/item/storage/fancy/donut_box{
+	pixel_y = 5
 	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 8
-	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "nqg" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-02"
+/obj/structure/toilet{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood)
 "nqr" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -13772,24 +15550,29 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "nrx" = (
-/obj/structure/toilet{
-	dir = 1;
-	pixel_y = -2
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "white"
+/obj/machinery/door/airlock/grunge{
+	name = "Knight Commander's Office";
+	req_access_txt = "120"
 	},
-/area/f13/brotherhood/offices1st)
+/turf/open/water,
+/area/f13/brotherhood)
 "nua" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "white"
-	},
-/area/f13/brotherhood/offices1st)
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "nuA" = (
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/f13{
@@ -13797,13 +15580,18 @@
 	},
 /area/f13/followers)
 "nvm" = (
-/obj/machinery/door/airlock/hatch{
-	id_tag = "Baron1";
-	name = "Baron's Office";
-	req_access_txt = "120"
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 5
 	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "nxk" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck{
@@ -13813,8 +15601,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "nxn" = (
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/armory)
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
+	},
+/obj/machinery/camera/autoname{
+	dir = 8;
+	name = "Armory Camera";
+	network = list("BoS");
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/pet/cat/Runtime{
+	name = "Knight Captain Proctor"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
 "nyH" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/tunnel/bighorn)
@@ -13825,24 +15626,19 @@
 	},
 /area/f13/tunnel)
 "nzp" = (
-/obj/structure/curtain,
-/obj/structure/decoration/vent,
-/obj/machinery/shower{
-	dir = 1
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
+/obj/item/lighter,
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = -32
 	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "nzR" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
+/obj/structure/bookcase/manuals/engineering,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "nzS" = (
 /obj/structure/sign/poster/contraband/pinup_topless{
@@ -13852,12 +15648,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "nAc" = (
-/obj/machinery/computer/rdconsole/core/bos{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/darkpurple/side,
-/area/f13/brotherhood/archives)
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/brotherhood)
 "nAW" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/f13{
@@ -13879,13 +15671,13 @@
 	},
 /area/f13/followers)
 "nDp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/structure/chair/bench,
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "nDw" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -13894,12 +15686,10 @@
 	},
 /area/f13/tunnel)
 "nEP" = (
-/obj/machinery/door/airlock/hatch{
-	id_tag = "knights2";
-	name = "Knight Quarters"
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/dorms)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13/vault,
+/area/f13/brotherhood)
 "nGd" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/large{
@@ -13928,13 +15718,26 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"nIl" = (
-/obj/machinery/light{
+"nHJ" = (
+/obj/machinery/sleeper{
+	density = 1;
 	dir = 4
 	},
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/freezer,
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
+"nIl" = (
+/obj/machinery/camera/autoname{
+	dir = 6;
+	name = "South Facing Camera";
+	network = list("BoS")
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "nJc" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -13959,12 +15762,12 @@
 	},
 /area/f13/tunnel)
 "nKw" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superlow,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 8
+/obj/structure/statue/bos/ladyright{
+	pixel_y = 11
 	},
-/area/f13/brotherhood/armory)
+/obj/structure/table/reinforced,
+/turf/open/floor/plating/dirt/dark,
+/area/f13/brotherhood)
 "nKR" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -13996,16 +15799,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "nOc" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "Marshal1";
-	name = "Marshal Office";
-	normaldoorcontrol = 1;
-	req_access_txt = "120";
-	specialfunctions = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
 "nOj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
@@ -14026,20 +15822,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "nPi" = (
-/obj/structure/table/reinforced,
-/obj/item/circuitboard/machine/cell_charger,
-/obj/item/circuitboard/machine/chem_dispenser,
-/obj/item/circuitboard/machine/chem_heater,
-/obj/item/circuitboard/machine/chem_master,
-/obj/item/circuitboard/machine/reagentgrinder,
-/obj/item/circuitboard/machine/sleeper,
-/obj/item/circuitboard/machine/sleeper,
-/obj/item/circuitboard/computer/operating,
-/obj/item/circuitboard/machine/plantgenes,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 4
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = -32
 	},
-/area/f13/brotherhood/archives)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood)
 "nPj" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibdown1"
@@ -14052,56 +15843,28 @@
 	},
 /area/f13/building/massfusion)
 "nPk" = (
-/obj/machinery/light{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 4
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/area/f13/brotherhood/archives)
+/area/f13/brotherhood)
 "nPC" = (
 /obj/effect/overlay/junk/telescreen,
 /turf/closed/wall/r_wall/rust,
 /area/f13/tunnel)
 "nPD" = (
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/storage/belt/military/army,
-/obj/item/storage/belt/military/army,
-/obj/item/storage/belt/military/army,
-/obj/item/storage/belt/military/army,
-/obj/item/storage/belt/military/army,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
 	},
-/obj/effect/turf_decal/bot_red,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/clothing/under/syndicate/brotherhood,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 4
+/obj/structure/mirror{
+	pixel_x = -30
 	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood)
 "nQj" = (
 /obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood,
@@ -14114,15 +15877,21 @@
 	},
 /area/f13/tunnel)
 "nSx" = (
-/obj/machinery/mineral/ore_redemption,
-/obj/structure/window/reinforced/tinted{
-	dir = 4
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
-/obj/structure/window/reinforced/tinted{
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
 	dir = 8
 	},
-/turf/open/floor/pod/light,
-/area/f13/brotherhood/archives)
+/turf/open/water,
+/area/f13/brotherhood)
 "nSM" = (
 /obj/item/trash/cheesie,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -14149,10 +15918,9 @@
 	},
 /area/f13/tunnel/bighorn)
 "nTS" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/darkblue/side,
+/obj/structure/rack/shelf_metal,
+/obj/item/circuitboard/machine/plantgenes,
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood)
 "nUg" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14165,11 +15933,19 @@
 	},
 /area/f13/building/massfusion)
 "nVS" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Interrogation Observation";
-	req_access_txt = "120"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/turf/open/floor/plasteel/darkred,
+/area/f13/brotherhood)
+"nWO" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhdirty_chess2"
+	},
 /area/f13/brotherhood)
 "nWP" = (
 /obj/machinery/light{
@@ -14199,10 +15975,8 @@
 	},
 /area/f13/followers)
 "nZR" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/darkred,
+/obj/structure/sign/poster/prewar/poster61,
+/turf/closed/wall/r_wall/f13/vault,
 /area/f13/brotherhood)
 "oai" = (
 /obj/machinery/light{
@@ -14254,13 +16028,21 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "odn" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/vending/hydroseeds{
+	force_free = 1
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
+"odU" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood)
 "oew" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -14282,6 +16064,27 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"ogj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/gun/energy/laser/aer9,
+/obj/item/gun/energy/laser/aer9,
+/obj/item/gun/energy/laser/aer9,
+/obj/item/gun/energy/laser/aer9,
+/obj/item/gun/energy/laser/aer9,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
+"ogR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
+	},
+/area/f13/brotherhood)
 "oiF" = (
 /obj/structure/simple_door/repaired{
 	name = "Private Pub Backroom"
@@ -14293,11 +16096,16 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "oiJ" = (
-/obj/structure/chair/office/light{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhdirty_chess2"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "oiW" = (
 /obj/structure/sign/poster/prewar/poster62{
 	pixel_x = 32
@@ -14306,10 +16114,16 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel/bighorn)
+"ojX" = (
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/autolathe/ammo/unlocked,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "okh" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/circuitboard/machine/destructive_analyzer,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/purple,
 /area/f13/brotherhood)
 "olf" = (
 /obj/effect/decal/cleanable/chem_pile,
@@ -14342,19 +16156,15 @@
 	},
 /area/f13/bunker)
 "omy" = (
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/brotherhood)
 "omE" = (
-/obj/structure/table/glass,
-/obj/machinery/cell_charger,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
-	},
-/area/f13/brotherhood/archives)
+/obj/structure/ore_box,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/brotherhood)
 "omG" = (
 /obj/structure/dresser,
 /turf/open/floor/f13/wood,
@@ -14503,10 +16313,17 @@
 	},
 /area/f13/tunnel)
 "otJ" = (
-/turf/open/floor/f13{
-	icon_state = "white"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/area/f13/brotherhood/offices1st)
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "otR" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/turf_decal/weather/dirt{
@@ -14516,6 +16333,15 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"ouS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood)
 "ovs" = (
 /obj/machinery/button/door{
 	id = "rustedshutters";
@@ -14529,32 +16355,39 @@
 	},
 /area/f13/tunnel)
 "ovP" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 4;
+	pixel_y = 8
 	},
-/obj/structure/filingcabinet/chestdrawer/wheeled{
-	pixel_y = 24
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_y = 6
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/grimy,
 /area/f13/brotherhood)
 "ovV" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/hatch{
-	name = "Armory";
-	req_access_txt = "120"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/vault,
-/area/f13/brotherhood/armory)
-"owd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
+"owd" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	barefootstep = "water";
+	clawfootstep = "water";
+	desc = "Shallow water.";
+	footstep = "water";
+	heavyfootstep = "water";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "riverwater_motion";
+	name = "water"
+	},
+/area/f13/brotherhood)
 "oxf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -14566,12 +16399,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/building/museum)
 "oxw" = (
-/obj/machinery/light/small,
-/obj/machinery/space_heater,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "bosdorm7";
+	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
 /area/f13/brotherhood)
 "oxK" = (
 /obj/effect/decal/remains/human,
@@ -14604,9 +16439,11 @@
 /turf/open/floor/wood/wood_common,
 /area/f13/tunnel/bighorn)
 "oCe" = (
-/turf/open/floor/plasteel/darkred/side{
-	dir = 5
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/brotherhood)
 "oCK" = (
 /obj/machinery/vending/cigarette,
@@ -14625,16 +16462,11 @@
 	},
 /area/f13/followers)
 "oDv" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/fence{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/mortar_shells,
-/obj/item/mortar_kit,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
-	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "oDA" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -14642,14 +16474,9 @@
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/building/massfusion)
 "oEg" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
 /area/f13/brotherhood)
 "oEi" = (
@@ -14658,15 +16485,19 @@
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "oEl" = (
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 4
-	},
-/area/f13/brotherhood/archives)
-"oEO" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
+"oEO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "oFi" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14675,8 +16506,11 @@
 	},
 /area/f13/tunnel)
 "oFB" = (
-/turf/open/floor/plasteel/darkred/side{
-	dir = 6
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
 "oGo" = (
@@ -14694,12 +16528,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "oGI" = (
-/obj/machinery/light{
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/turf/open/water,
+/area/f13/brotherhood)
 "oGU" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal/fifty,
@@ -14727,12 +16564,18 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"oIm" = (
-/obj/effect/spawner/structure/window/plastitanium,
-/obj/structure/cable{
-	icon_state = "0-8"
+"oIb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
+"oIm" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/brotherhood)
 "oIz" = (
 /obj/effect/turf_decal/caution{
@@ -14746,11 +16589,20 @@
 /area/f13/building/museum)
 "oIL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/mattress/pregame,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	layer = 2.7;
+	name = "prewar lounge chair"
 	},
-/turf/open/floor/mineral/plastitanium,
+/obj/machinery/camera/autoname{
+	dir = 6;
+	name = "South Facing Camera";
+	network = list("BoS")
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/darkpurple,
 /area/f13/brotherhood)
 "oJn" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -14759,10 +16611,21 @@
 	},
 /area/f13/bunker)
 "oJw" = (
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 6
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "stagestairs"
 	},
-/area/f13/brotherhood/archives)
+/area/f13/brotherhood)
+"oJz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "oJK" = (
 /obj/structure/railing{
 	dir = 4
@@ -14774,12 +16637,18 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/tunnel/bighorn)
 "oKn" = (
+/obj/machinery/door/airlock/hatch{
+	id_tag = "knightc1";
+	name = "Knight-Commander Office";
+	req_access_txt = "120"
+	},
 /turf/open/floor/plasteel/darkbrown/side,
 /area/f13/brotherhood)
 "oLs" = (
-/obj/effect/landmark/start/f13/elder,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/machinery/rnd/production/circuit_imprinter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "oMg" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/f13{
@@ -14787,12 +16656,12 @@
 	},
 /area/f13/bunker)
 "oMu" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/brotherhood)
 "oMS" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -14825,10 +16694,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel/bighorn)
 "oNP" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/status_display/supply{
+	pixel_y = 32
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/brotherhood)
 "oOp" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14838,9 +16707,9 @@
 /area/f13/tunnel)
 "oOV" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "oPl" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -14852,17 +16721,43 @@
 	},
 /area/f13/tunnel)
 "oPY" = (
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/brotherhood/armory)
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8;
+	pixel_y = 10
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "oQo" = (
 /obj/structure/decoration/warning,
 /turf/closed/indestructible/f13vaultrusted{
 	name = "rusty reinforced wall"
 	},
 /area/f13/tunnel/bighorn)
+"oQC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "oRj" = (
-/turf/open/floor/plasteel/darkpurple,
-/area/f13/brotherhood/archives)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/power/port_gen/pacman/super{
+	anchored = 1
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "oSc" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/museum)
@@ -14873,16 +16768,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "oSF" = (
+/obj/structure/chair/bench,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 1
-	},
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood)
 "oTg" = (
 /obj/machinery/light/small{
@@ -14901,10 +16789,24 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "oUx" = (
-/obj/structure/chair{
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/water,
 /area/f13/brotherhood)
 "oUM" = (
 /obj/structure/table/wood/settler,
@@ -14940,23 +16842,25 @@
 	},
 /area/f13/brotherhood)
 "oXy" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/grunge{
+	name = "Baron's Office";
+	req_access_txt = "120"
+	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 4
-	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
 "oXR" = (
 /obj/structure/bed/pod,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/building/museum)
 "oYO" = (
-/obj/structure/dresser,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/brotherhood)
 "oZU" = (
 /obj/effect/spawner/lootdrop/f13/cash_ncr_med,
 /turf/open/floor/f13/wood,
@@ -14977,10 +16881,12 @@
 	},
 /area/f13/building/massfusion)
 "pbB" = (
-/obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet/purple,
+/area/f13/brotherhood)
 "pcA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/unpowered/securedoor{
@@ -15037,15 +16943,18 @@
 	},
 /area/f13/tunnel)
 "pif" = (
-/obj/machinery/light{
-	dir = 4
+/obj/effect/landmark/start/f13/elder,
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	layer = 2.7;
+	name = "prewar lounge chair"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "piz" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault/corner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/purple,
 /area/f13/brotherhood)
 "piA" = (
 /obj/structure/junk/small/table,
@@ -15076,15 +16985,20 @@
 	},
 /area/f13/building/massfusion)
 "pjX" = (
-/obj/machinery/light{
-	dir = 8
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/item/cigbutt,
+/obj/structure/table{
+	pixel_y = 6
+	},
+/obj/item/pen/fourcolor{
+	pixel_y = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 8
-	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "pkF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -15120,23 +17034,43 @@
 	},
 /area/f13/tunnel)
 "plP" = (
-/obj/structure/filingcabinet/chestdrawer/wheeled{
-	pixel_y = 24
+/obj/structure/table/survival_pod,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 12
 	},
-/turf/open/floor/plasteel/dark,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 5
+	},
+/obj/item/newspaper{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/obj/machinery/camera/autoname{
+	dir = 5;
+	name = "Reactor Camera";
+	network = list("BoS")
+	},
+/obj/machinery/camera/autoname{
+	dir = 6;
+	name = "South Facing Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
 /area/f13/brotherhood)
 "pmb" = (
-/obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "pmx" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/effect/turf_decal/box,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/item/multitool,
+/obj/item/screwdriver,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/area/f13/brotherhood)
 "pmD" = (
 /obj/structure/closet{
 	storage_capacity = 10
@@ -15152,21 +17086,21 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"pmH" = (
+/obj/machinery/rnd/production/protolathe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "pmW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/item/am_containment,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "pna" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/hatch{
-	name = "Armory";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/vault,
-/area/f13/brotherhood/armory)
+/obj/machinery/mineral/ore_redemption,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/brotherhood)
 "pnV" = (
 /obj/machinery/workbench/advanced,
 /obj/item/storage/part_replacer,
@@ -15179,16 +17113,30 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "ppn" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowbottom"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
+	},
+/area/f13/brotherhood)
 "ppo" = (
 /obj/structure/campfire,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"ppq" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/pen{
+	pixel_x = -16;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "pqy" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/building/museum)
@@ -15216,45 +17164,49 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/followers)
 "prD" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/melee/onehanded/machete/training,
-/obj/item/melee/onehanded/machete/training{
-	pixel_y = 6
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/vault{
+	name = "Engine Access";
+	req_access_txt = "120"
 	},
-/obj/item/melee/onehanded/machete/training{
-	pixel_y = -6
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "prW" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/building/museum)
 "psa" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Paladin Quarters";
-	req_access_txt = "120"
+/obj/structure/chair/bench{
+	pixel_y = 15
 	},
-/turf/open/floor/plasteel/vault,
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood)
-"psR" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/darkpurple/side{
+"psO" = (
+/obj/structure/toilet{
 	dir = 4
 	},
-/area/f13/brotherhood/archives)
-"ptD" = (
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood)
+"psR" = (
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/hatch{
-	name = "Power";
-	req_access_txt = "120"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood)
+"ptD" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "pur" = (
 /obj/structure/closet,
 /obj/item/clothing/under/f13/female/flapper,
@@ -15286,40 +17238,37 @@
 	},
 /area/f13/tunnel)
 "pvA" = (
-/obj/machinery/computer/cargo{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/closet/crate/wooden,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/brotherhood)
 "pvC" = (
 /obj/structure/table/reinforced,
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Business"
-	},
+/obj/machinery/computer/terminal,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "pvU" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/minigunpackbal5mm,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "pwh" = (
-/obj/structure/table/glass,
-/obj/structure/bedsheetbin,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/open/floor/f13{
-	icon_state = "white"
+	icon_state = "reddirtyfull"
 	},
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood)
+"pwv" = (
+/obj/structure/noticeboard{
+	name = "display plate";
+	pixel_y = 34
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood)
 "pwB" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib2-old"
@@ -15337,14 +17286,15 @@
 	},
 /area/f13/tunnel)
 "pxF" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal{
-	dir = 4;
-	pixel_y = 5;
-	termtag = "Business"
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
 	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/turf/open/water,
+/area/f13/brotherhood)
 "pxX" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
 /obj/effect/turf_decal/vg_decals/numbers/two{
@@ -15374,36 +17324,63 @@
 /turf/open/floor/wood/wood_common,
 /area/f13/tunnel/bighorn)
 "pAo" = (
-/turf/open/floor/pod/light,
-/area/f13/brotherhood)
-"pAE" = (
-/obj/structure/railing{
+/obj/effect/turf_decal/caution{
 	dir = 4
 	},
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/brotherhood/medical)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
+"pAE" = (
+/obj/item/multitool,
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood)
 "pAU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plating,
 /area/f13/building/museum)
-"pBq" = (
-/obj/structure/chair/office/light,
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/archives)
-"pBx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
+"pAW" = (
+/obj/machinery/conveyor{
+	dir = 5;
+	id = "QMLoad2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/fence/handrail{
 	dir = 4;
-	light_color = "#c1caff"
+	pixel_x = -15
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/vault/side{
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/area/f13/brotherhood)
+"pBq" = (
+/obj/machinery/sleeper{
+	density = 1;
 	dir = 4
 	},
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
+"pBx" = (
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/under/syndicate/brotherhood,
+/obj/item/clothing/under/f13/bosformgold_f,
+/obj/item/clothing/under/f13/bosformgold_m,
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "pBQ" = (
 /obj/structure/table/wood/settler,
@@ -15435,25 +17412,29 @@
 	},
 /area/f13/building/massfusion)
 "pEf" = (
-/obj/item/pda/captain,
-/obj/structure/table/reinforced,
-/obj/item/folder/syndicate/red{
-	desc = "A folder stamped \"Top Secret - Property of The Brotherhood.\""
+/obj/structure/table/optable,
+/obj/machinery/iv_drip{
+	pixel_x = 15;
+	pixel_y = -2
 	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/offices1st)
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "pFU" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "pGE" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 8
-	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/filingcabinet,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "pGJ" = (
 /obj/structure/toilet{
@@ -15470,17 +17451,17 @@
 	},
 /area/f13/tunnel)
 "pGM" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/button/door{
+	id = "sentdorm";
+	normaldoorcontrol = 1;
+	pixel_y = -25;
+	specialfunctions = 4
 	},
-/obj/machinery/sleeper{
+/obj/structure/chair/sofa/corp/corner{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "white"
-	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "pGY" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13{
@@ -15499,10 +17480,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/building/museum)
 "pHE" = (
-/obj/structure/table/wood,
-/obj/item/toy/cards/deck,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/dorms)
+/obj/machinery/camera/autoname{
+	dir = 6;
+	name = "South Facing Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "pHH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/f13vault{
@@ -15520,12 +17504,9 @@
 	},
 /area/f13/tunnel)
 "pII" = (
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = 33
-	},
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/freezer,
-/area/f13/brotherhood/medical)
+/obj/item/am_shielding_container,
+/turf/open/floor/plating,
+/area/f13/brotherhood)
 "pIL" = (
 /obj/item/storage/trash_stack,
 /obj/effect/decal/cleanable/dirt,
@@ -15540,38 +17521,27 @@
 	},
 /area/f13/tunnel)
 "pJG" = (
-/obj/structure/closet/crate/secure/weapon{
-	anchored = 1
-	},
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/effect/turf_decal/bot_red,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/corner{
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
-/area/f13/brotherhood/armory)
-"pKe" = (
-/turf/open/floor/plasteel/darkred/side{
-	dir = 4
-	},
-/area/f13/brotherhood/armory)
-"pLs" = (
-/obj/item/flag/bos{
-	density = 0;
-	pixel_y = 30
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
+"pKe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
+"pLs" = (
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
+/obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "pLN" = (
@@ -15588,11 +17558,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "pMJ" = (
-/obj/structure/chair/sofa/corp{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "pMV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -15622,16 +17595,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel/bighorn)
+"pOy" = (
+/obj/machinery/camera/autoname{
+	dir = 5;
+	name = "Reactor Camera";
+	network = list("BoS")
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood)
 "pOB" = (
-/obj/machinery/shower{
-	pixel_y = 27
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/structure/curtain,
-/obj/item/soap,
-/turf/open/floor/f13{
-	icon_state = "white"
-	},
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/mineral/plastitanium,
+/area/f13/brotherhood)
 "pPw" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/stack/f13Cash/random/ncr/high,
@@ -15642,13 +17623,13 @@
 	},
 /area/f13/tunnel/bighorn)
 "pPC" = (
-/obj/machinery/door/airlock/hatch{
-	id_tag = "Castellan1";
-	name = "Castellan Room";
-	req_access_txt = "120"
+/obj/structure/bed/mattress{
+	icon_state = "mattress5"
 	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood)
 "pPX" = (
 /obj/machinery/workbench/forge,
 /obj/item/traumapack,
@@ -15666,11 +17647,33 @@
 /obj/effect/decal/waste,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"pSP" = (
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 9
+"pSt" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/medsprays,
+/obj/item/pda/chemist{
+	name = "Scribe-Chemist Pip-Boy 3000";
+	pixel_x = 15;
+	pixel_y = 7
 	},
-/area/f13/brotherhood/archives)
+/obj/item/reagent_containers/dropper,
+/obj/machinery/reagentgrinder{
+	layer = 3.3;
+	pixel_x = -1;
+	pixel_y = 15
+	},
+/obj/item/reagent_containers/dropper,
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
+"pSP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "pSZ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -15710,19 +17713,28 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "pWb" = (
-/obj/structure/bed/pod,
-/obj/structure/curtain,
-/turf/open/floor/f13{
-	icon_state = "white"
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
-/area/f13/brotherhood/medical)
-"pXb" = (
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/survival_pod/glass{
-	name = "cell airlock";
-	req_access_txt = "120"
-	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/water,
+/area/f13/brotherhood)
+"pXb" = (
+/obj/machinery/rnd/production/protolathe,
+/turf/open/floor/plasteel/darkpurple,
 /area/f13/brotherhood)
 "pXj" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -15741,20 +17753,44 @@
 	},
 /area/f13/tunnel)
 "pXS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault/side{
-	dir = 10
+/obj/structure/chair/office/light{
+	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood)
+"pXZ" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/paper_bin{
+	pixel_x = 16;
+	pixel_y = 5
+	},
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/item/pen/fountain{
+	pixel_x = 15;
+	pixel_y = 5
+	},
+/obj/item/book/granter/trait/chemistry,
+/obj/item/book/granter/trait/chemistry,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "pYk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/conveyor/inverted{
+	dir = 8;
+	id = "garbage"
 	},
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "QMUnload"
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera/autoname{
+	dir = 6;
+	name = "South Facing Camera";
+	network = list("BoS")
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/brotherhood)
 "pYY" = (
 /obj/structure/railing{
@@ -15777,6 +17813,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/building/museum)
+"qat" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Knight Commander's Office";
+	req_access_txt = "120"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "qbT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
@@ -15785,25 +17828,31 @@
 	},
 /area/f13/tunnel)
 "qbZ" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
 	},
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_x = 32
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/brotherhood/reactor)
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	layer = 2.7;
+	pixel_y = 17
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "qcd" = (
-/obj/machinery/button/door{
-	id = "Castellan1";
-	name = "Castellan Room";
-	normaldoorcontrol = 1;
-	pixel_x = -32;
-	req_access_txt = "120";
-	specialfunctions = 4
+/obj/structure/chair/bench{
+	icon_state = "dropshipright"
 	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "qce" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -15855,15 +17904,21 @@
 	},
 /area/f13/tunnel)
 "qfa" = (
-/obj/structure/dresser,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
-"qfo" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/vending/wardrobe/chem_wardrobe,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/turf/open/floor/plasteel/vault/corner{
-	dir = 1
+/area/f13/brotherhood)
+"qfo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/gun/energy/laser/pistol,
+/obj/item/gun/energy/laser/pistol,
+/obj/item/gun/energy/laser/pistol,
+/obj/item/gun/energy/laser/pistol,
+/obj/item/gun/energy/laser/pistol,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood)
 "qhp" = (
@@ -15874,12 +17929,17 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"qiz" = (
-/obj/machinery/light/small{
-	dir = 8
+"qio" = (
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
+"qiz" = (
+/obj/item/flag/bos,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "qiB" = (
 /obj/machinery/light/small{
@@ -15888,10 +17948,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qiR" = (
-/obj/structure/bed,
-/obj/item/bedsheet/black,
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/dorms)
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowright"
+	},
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "qjm" = (
 /obj/structure/rack,
 /obj/item/electropack/shockcollar{
@@ -15915,8 +17979,22 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/building/museum)
 "qju" = (
-/obj/effect/landmark/start/f13/initiate,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 23;
+	start_charge = 500
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "qjR" = (
 /obj/effect/decal/cleanable/oil,
@@ -15933,19 +18011,29 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/tunnel)
+"qkE" = (
+/obj/machinery/shower{
+	pixel_y = 27
+	},
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
+/obj/structure/decoration/vent,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood)
 "qkN" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/brotherhood/dorms)
-"qmd" = (
-/obj/machinery/chem_dispenser/drinks/beer{
-	density = 0;
-	dir = 1;
-	pixel_y = -15
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
+/area/f13/brotherhood)
+"qmd" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "qmg" = (
 /obj/structure/chair/right{
 	dir = 1
@@ -15954,10 +18042,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building/museum)
 "qmp" = (
-/obj/machinery/vending/engineering,
+/obj/structure/rack/shelf_metal,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/armory)
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/gloves/combat,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "qmt" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/turf_decal/weather/dirt,
@@ -15966,26 +18056,49 @@
 	},
 /area/f13/building/massfusion)
 "qmH" = (
-/obj/structure/sign/poster/official/foam_force_ad,
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/brotherhood)
-"qnu" = (
-/obj/structure/rack,
-/obj/item/gun/energy/laser/pistol,
-/obj/item/gun/energy/laser/pistol,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "QMLoad"
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/area/f13/brotherhood/armory)
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/area/f13/brotherhood)
+"qnu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "qof" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/machinery/door/airlock/hatch{
-	name = "Castellan Toilet";
 	req_access_txt = "120"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
+"qoh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "qom" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -16004,26 +18117,24 @@
 /turf/open/floor/f13/wood,
 /area/f13/followers)
 "qpr" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/structure/table/wood,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "qps" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building/museum)
 "qpx" = (
-/turf/open/floor/plasteel/vault/side{
-	dir = 10
+/obj/structure/table/wood/poker,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood)
 "qqb" = (
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "qqi" = (
 /obj/machinery/vending/cigarette,
@@ -16054,24 +18165,26 @@
 	},
 /area/f13/tunnel)
 "qrP" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/structure/fence,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4;
+	pixel_x = -7
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "qsi" = (
 /obj/structure/barricade/wooden,
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "qtd" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "120"
+/obj/structure/lattice{
+	layer = 3
 	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
+/turf/open/floor/bronze{
+	name = "floor"
 	},
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood)
 "qtA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -16085,16 +18198,23 @@
 	},
 /area/f13/tunnel)
 "qtK" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	pixel_y = 5
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 6;
+	pixel_x = 13
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 9;
+	pixel_x = 13
+	},
+/obj/item/clothing/gloves/boxing{
+	pixel_x = 13
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "quH" = (
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/brotherhood/leisure)
+/obj/structure/simple_door/bunker/glass,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "quQ" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/indestructible/ground/inside/mountain,
@@ -16107,11 +18227,18 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/building/museum)
 "qwx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/brotherhood/reactor)
+/turf/closed/indestructible/vaultdoor{
+	desc = "A wall built to withstand an atomic explosion.";
+	icon = 'icons/fallout/turfs/walls/vault_reinforced.dmi';
+	icon_state = "vaultrwall0";
+	icon_type_smooth = "vaultrwall";
+	name = "vault reinforced wall"
+	},
+/area/f13/brotherhood)
 "qwU" = (
 /obj/structure/noticeboard,
 /turf/closed/wall/rust,
@@ -16121,52 +18248,48 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "qxD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/darkbrown/side{
-	dir = 8
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood)
 "qyr" = (
-/obj/structure/closet/cabinet,
-/obj/item/folder/documents{
-	desc = "A folder stamped \"Top Secret - Property of The Brotherhood.\""
-	},
-/obj/item/clothing/suit/f13/elder,
-/obj/item/clothing/accessory/bos/elder,
-/obj/item/storage/firstaid/regular,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "qyx" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13,
-/area/f13/brotherhood/armory)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
 "qyI" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/tunnel/bighorn)
 "qyT" = (
-/obj/item/storage/backpack/satchel/flat/secret{
-	layer = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/archives)
-"qyY" = (
-/obj/structure/bed,
-/obj/item/bedsheet/black,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/door{
-	id = "scribes2";
-	name = "Scribe Room 2";
+	id = "bosdorm8";
 	normaldoorcontrol = 1;
-	pixel_x = 32;
-	req_access_txt = "120";
+	pixel_x = 28;
 	specialfunctions = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
+"qyY" = (
+/obj/machinery/conveyor{
+	dir = 9;
+	id = "garbage"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/fence/handrail{
+	dir = 4;
+	pixel_x = -15
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
 "qzp" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -16176,11 +18299,26 @@
 	},
 /area/f13/followers)
 "qzt" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 9
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
-/area/f13/brotherhood/archives)
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
+	},
+/turf/open/water,
+/area/f13/brotherhood)
 "qzD" = (
 /obj/structure/sink{
 	pixel_y = 19
@@ -16219,18 +18357,32 @@
 /obj/machinery/workbench/advanced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
+"qDT" = (
+/obj/machinery/sleeper{
+	density = 1;
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "qDU" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/sewer)
 "qDV" = (
-/obj/structure/chair/office/dark{
-	dir = 4
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/machinery/radioterminal/bos{
+	dir = 8;
+	pixel_x = 27;
+	pixel_y = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "qEb" = (
 /obj/structure/barricade/wooden{
 	layer = 2.5
@@ -16244,25 +18396,44 @@
 	},
 /area/f13/tunnel)
 "qFr" = (
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/water,
 /area/f13/brotherhood)
 "qGw" = (
-/obj/effect/landmark/start/f13/initiate,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault/side{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
+/turf/open/floor/plasteel/darkpurple,
 /area/f13/brotherhood)
 "qGz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhdirty_chess2"
+	},
+/area/f13/brotherhood)
 "qGK" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -16271,25 +18442,24 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel/bighorn)
 "qGX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
+"qGY" = (
 /obj/structure/chair/comfy/shuttle{
 	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
-	dir = 4;
+	dir = 1;
 	name = "prewar lounge chair"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
-"qGY" = (
-/obj/machinery/button/door{
-	id = "Marshal2";
-	name = "Marshal Room";
-	normaldoorcontrol = 1;
-	pixel_x = 32;
-	req_access_txt = "120";
-	specialfunctions = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "qHu" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_north_middle"
@@ -16300,6 +18470,16 @@
 	},
 /turf/open/floor/wood/wood_common,
 /area/f13/tunnel/bighorn)
+"qHQ" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	icon_state = "twindowold"
+	},
+/obj/structure/toilet{
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood)
 "qHU" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
@@ -16368,19 +18548,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "qMG" = (
-/obj/machinery/door/unpowered/secure_bos,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/structure/simple_door/metal/fence,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "qNe" = (
-/obj/effect/turf_decal/box,
-/obj/structure/closet/crate,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/brotherhood)
 "qNj" = (
-/obj/structure/table/wood,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/dorms)
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "qNG" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
@@ -16405,11 +18582,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel/bighorn)
 "qPd" = (
-/obj/structure/table/reinforced,
-/obj/item/card/id/dogtag,
-/obj/item/card/id/dogtag,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/machinery/door/airlock/grunge{
+	name = "Knight Commander's Office";
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood)
 "qPV" = (
 /obj/structure/sink{
 	dir = 4;
@@ -16418,15 +18596,24 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "qPZ" = (
-/obj/structure/decoration/clock/active,
-/turf/closed/wall/r_wall/f13/vault,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	pixel_y = 25
+	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "qQK" = (
-/obj/machinery/door/airlock/survival_pod/glass{
-	name = "cell airlock";
-	req_access_txt = "120"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/open/floor/mineral/plastitanium,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "qRH" = (
 /obj/machinery/vending/wardrobe/chem_wardrobe{
@@ -16446,19 +18633,22 @@
 	},
 /area/f13/building/massfusion)
 "qUn" = (
-/obj/item/storage/secure/safe{
-	pixel_x = 4;
-	pixel_y = 30
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
-/obj/structure/sign/poster/official/science{
-	pixel_y = 30
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
 	},
-/obj/structure/closet/crate/rcd,
-/obj/item/construction/rld,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
 	},
-/area/f13/brotherhood/archives)
+/turf/open/water,
+/area/f13/brotherhood)
 "qUT" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -16473,13 +18663,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/massfusion)
 "qVd" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood)
 "qVR" = (
 /mob/living/simple_animal/hostile/raider/ranged/biker{
@@ -16527,13 +18715,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "qZg" = (
-/obj/effect/turf_decal/box,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
-/obj/structure/closet/crate/wooden,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood)
 "raI" = (
 /obj/structure/ore_box,
@@ -16561,14 +18743,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "rdL" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Business"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood)
 "ref" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -16577,41 +18760,64 @@
 	},
 /area/f13/tunnel)
 "reU" = (
-/obj/structure/stairs/north,
-/turf/open/floor/f13{
-	icon_state = "white"
+/obj/machinery/door/airlock/grunge{
+	name = "Elder's Office";
+	req_access_txt = "120"
 	},
-/area/f13/brotherhood/medical)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "reW" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/warning,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
+"rfX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/pet/dog/eyebot/dense,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
 "rga" = (
-/obj/machinery/rnd/production/protolathe,
-/turf/open/floor/plasteel/darkpurple/side,
-/area/f13/brotherhood/archives)
+/obj/structure/table/wood/settler,
+/obj/item/toy/plush/lampplushie{
+	pixel_y = 5
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "rgl" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel/bighorn)
 "rgE" = (
-/obj/machinery/washing_machine,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/brotherhood/leisure)
-"rgG" = (
 /obj/structure/chair/comfy/shuttle{
-	dir = 1
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	layer = 2.7;
+	name = "prewar lounge chair"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/sentinel,
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
+"rgG" = (
+/obj/structure/table/wood/poker,
 /turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "rgS" = (
-/obj/structure/railing,
-/turf/closed/wall/r_wall/f13/vault,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood)
 "rhV" = (
 /obj/item/storage/trash_stack{
@@ -16621,15 +18827,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel/bighorn)
 "rhX" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Medical Bay";
-	req_access_txt = "120"
-	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
+	},
+/area/f13/brotherhood)
 "riD" = (
 /obj/structure/mopbucket,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -16645,19 +18850,26 @@
 /turf/open/floor/plating,
 /area/f13/tunnel)
 "rmQ" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/circuitboard/machine/limbgrower,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/brotherhood)
-"rmR" = (
-/obj/structure/toilet{
-	dir = 1;
-	pixel_y = -2
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/f13{
-	icon_state = "white"
+	icon_state = "reddirtyfull"
 	},
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
+"rmR" = (
+/obj/structure/reagent_dispensers/keg,
+/obj/structure/table/wood/settler,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "rnh" = (
 /turf/closed/indestructible/rock,
 /area/f13/tunnel)
@@ -16713,11 +18925,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "rri" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Interrogation";
-	req_access_txt = "120"
+/obj/structure/bed,
+/obj/item/bedsheet/rd{
+	desc = "A fine quilted blanket, made with purple and yellow fabric.";
+	dream_messages = list("authority","a                                                                silvery                                                                ID","a                                                                bomb","a                                                                mech","a                                                                facehugger","maniacal                                                                laughter");
+	name = "fine bedsheet"
 	},
-/turf/open/floor/plasteel/darkred,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "rrI" = (
 /obj/effect/landmark/start/f13/followersvolunteer,
@@ -16742,10 +18956,11 @@
 	},
 /area/f13/tunnel)
 "rte" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "ruW" = (
 /obj/structure/chair/wood{
@@ -16765,12 +18980,22 @@
 	},
 /area/f13/tunnel/bighorn)
 "rvy" = (
-/obj/structure/table/glass,
-/obj/machinery/cell_charger,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowright"
 	},
-/area/f13/brotherhood/archives)
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
+"rws" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
 "rwL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/trash_stack,
@@ -16795,25 +19020,19 @@
 	},
 /area/f13/tunnel)
 "ryt" = (
-/obj/structure/rack/shelf_metal,
-/obj/machinery/light/small,
-/obj/item/circuitboard/machine/plantgenes,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chalkboard{
+	pixel_x = -18
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "ryu" = (
 /obj/effect/gibspawner/human,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "ryF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/brotherhood/reactor)
+/turf/closed/mineral/random/low_chance,
+/area/f13/brotherhood)
 "rzw" = (
 /obj/machinery/light{
 	dir = 1;
@@ -16824,17 +19043,14 @@
 /turf/open/floor/plating,
 /area/f13/building/museum)
 "rzF" = (
-/obj/machinery/conveyor/inverted{
-	dir = 6;
-	id = "QMLoad"
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = -32
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "rAu" = (
 /obj/machinery/autolathe,
@@ -16865,19 +19081,25 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"rCb" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
 "rCd" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 3
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/vault/side{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/turf/open/water,
 /area/f13/brotherhood)
 "rCg" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
@@ -16888,21 +19110,33 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"rCs" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
+"rCL" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "rDp" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
-	dir = 8;
-	name = "prewar lounge chair"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "rEc" = (
+/obj/structure/closet/secure_closet/brig,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 1
+/turf/open/floor/f13{
+	icon_state = "redmark"
 	},
 /area/f13/brotherhood)
 "rFi" = (
@@ -16911,10 +19145,22 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel/bighorn)
 "rFX" = (
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/structure/chair/sofa/corp{
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
+"rGa" = (
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "120"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "rGr" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore"
@@ -16927,17 +19173,28 @@
 	},
 /area/f13/tunnel)
 "rGt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/chair/sofa/corp/right,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood)
 "rGz" = (
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
+"rHV" = (
+/obj/item/twohanded/required/kirbyplants/random{
+	pixel_y = 3;
+	pixel_x = 9
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "rID" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -16952,6 +19209,12 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/f13/tunnel/bighorn)
+"rJh" = (
+/obj/effect/turf_decal/loading_area/white{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "rJm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -16959,10 +19222,9 @@
 	},
 /area/f13/bunker)
 "rJw" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/structure/closet/ammunitionlocker,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "rJI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -16982,43 +19244,24 @@
 	},
 /area/f13/tunnel)
 "rLF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/vault/corner{
-	dir = 4
-	},
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "rMH" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/followers)
 "rMI" = (
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/pda/heads/hos,
-/obj/item/storage/briefcase,
-/obj/item/clothing/suit/armor/vest/capcarapace/syndicate{
-	desc = "A sinister looking vest of advanced armor worn over a black and red fireproof jacket. The gold collar and shoulders denote that this belongs to a high ranking officer of some lost prewar army.";
-	name = "old officer's vest"
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowtop"
 	},
-/obj/item/clothing/head/HoS/beret/syndicate{
-	name = "officer's beret"
-	},
-/obj/item/clothing/under/f13/bosformgold_m,
-/obj/item/clothing/under/f13/bosformgold_f,
-/obj/item/clothing/head/f13/boscap,
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
-	},
-/obj/item/clothing/head/helmet/f13/power_armor/t45d/Knightcommander,
-/obj/item/clothing/suit/armor/f13/power_armor/t45d/Knightcommander,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 10
-	},
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "rNn" = (
 /obj/machinery/smartfridge/bottlerack,
 /obj/structure/railing/wood{
@@ -17031,7 +19274,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/darkpurple/side,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood)
 "rOE" = (
 /obj/machinery/door/airlock,
@@ -17045,6 +19293,13 @@
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
+"rPq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/radiation{
+	anchored = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood)
 "rPt" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -17059,9 +19314,24 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "rRw" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/dna_probe,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/under/syndicate/brotherhood,
+/obj/item/storage/briefcase,
+/obj/item/clothing/head/HoS/beret/syndicate{
+	name = "officer's beret"
+	},
+/obj/item/clothing/under/f13/bosformgold_m,
+/obj/item/clothing/under/f13/bosformgold_f,
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
+	},
+/obj/item/pda{
+	icon_state = "pda-hos";
+	name = "Head Knight's PipBoy"
+	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "rSn" = (
 /obj/item/stack/sheet/mineral/uranium,
@@ -17084,10 +19354,11 @@
 	},
 /area/f13/tunnel/bighorn)
 "rUK" = (
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 10
+/obj/structure/chair/booth{
+	icon_state = "booth_east_south"
 	},
-/area/f13/brotherhood/archives)
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
 "rUU" = (
 /obj/item/clothing/head/helmet/knight/f13/metal/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -17131,6 +19402,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/camera/autoname{
+	dir = 6;
+	name = "South Facing Camera";
+	network = list("BoS")
+	},
 /turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
@@ -17153,18 +19429,18 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel/bighorn)
 "rWu" = (
-/obj/structure/railing{
-	dir = 9
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = 11
 	},
-/turf/closed/wall/r_wall/f13/vault,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/water,
 /area/f13/brotherhood)
 "rWA" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "rWC" = (
 /obj/structure/closet,
 /obj/item/storage/box/syringes,
@@ -17229,7 +19505,12 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/building/massfusion)
 "saZ" = (
-/obj/structure/table/reinforced,
+/obj/structure/chair/bench,
+/obj/machinery/camera/autoname{
+	dir = 6;
+	name = "South Facing Camera";
+	network = list("BoS")
+	},
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "sbd" = (
@@ -17262,17 +19543,13 @@
 	},
 /area/f13/tunnel)
 "sbH" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor{
-	req_access_txt = "255"
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/gun/energy/laser/plasma/pistol/remnant/is,
-/obj/item/clothing/head/helmet/f13/enclave/officer,
-/turf/open/floor/plasteel/vault,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
 /area/f13/brotherhood)
 "scA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17292,13 +19569,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/building/museum)
 "seX" = (
-/obj/machinery/door/airlock/hatch{
-	id_tag = "Keeper1";
-	name = "Keeper's Office";
-	req_access_txt = "120"
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "seZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/rust,
@@ -17310,6 +19586,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building/museum)
+"sgQ" = (
+/obj/machinery/smartfridge,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "sgV" = (
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
@@ -17329,12 +19611,9 @@
 /area/f13/building/museum)
 "siG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 9
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool,
+/turf/open/floor/carpet/purple,
 /area/f13/brotherhood)
 "siS" = (
 /obj/structure/handrail/g_central{
@@ -17355,14 +19634,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "skf" = (
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_y = 32
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
+/obj/item/paper_bin{
+	pixel_x = 16;
+	pixel_y = 5
 	},
+/obj/item/book/granter/trait/pa_wear,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "skw" = (
 /obj/item/storage/trash_stack{
@@ -17393,13 +19673,25 @@
 	},
 /area/f13/followers)
 "smj" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/item/clothing/under/f13/bosformgold_f,
+/obj/item/clothing/under/f13/bosformgold_m,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
+"smk" = (
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
+	},
+/turf/open/water,
 /area/f13/brotherhood)
 "smC" = (
 /obj/structure/rack/shelf_metal,
@@ -17439,13 +19731,12 @@
 	},
 /area/f13/tunnel)
 "snn" = (
-/obj/effect/turf_decal/box,
-/obj/item/circuitboard/machine/ore_silo,
-/obj/structure/frame/machine,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
+/obj/machinery/door/airlock/grunge{
+	name = "Elder's Office";
+	req_access_txt = "120"
 	},
-/area/f13/brotherhood/archives)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "soi" = (
 /obj/machinery/microwave/stove,
 /obj/effect/decal/cleanable/dirt,
@@ -17458,6 +19749,12 @@
 	},
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
+"soA" = (
+/obj/item/flag/bos,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood)
 "soK" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /obj/effect/decal/cleanable/dirt,
@@ -17466,13 +19763,23 @@
 	},
 /area/f13/tunnel)
 "soO" = (
-/obj/machinery/door/poddoor/ert{
-	id = "BOSPAS"
+/obj/structure/curtain{
+	color = "#5c131b"
 	},
-/obj/machinery/door/airlock/vault{
-	req_access_txt = "255"
+/obj/machinery/door/airlock/grunge{
+	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/vault,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
+"soR" = (
+/obj/structure/sign/poster/prewar/poster60,
+/turf/closed/wall/r_wall/f13/vault,
+/area/f13/brotherhood)
+"soX" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side,
 /area/f13/brotherhood)
 "sph" = (
 /obj/structure/rack,
@@ -17501,10 +19808,14 @@
 	},
 /area/f13/clinic)
 "srm" = (
-/turf/open/floor/plasteel/darkred/side{
-	dir = 5
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
 	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
 "srr" = (
 /obj/structure/curtain{
 	color = "#845f58";
@@ -17513,10 +19824,14 @@
 /turf/open/floor/wood/wood_common,
 /area/f13/tunnel/bighorn)
 "ssA" = (
-/obj/structure/table/reinforced,
-/obj/item/flashlight/lamp,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
+/obj/structure/closet,
+/obj/item/mining_scanner,
+/obj/item/clothing/glasses/meson,
+/obj/item/pickaxe/drill,
+/obj/structure/fans/tiny{
+	pixel_y = 32
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/brotherhood)
 "ssN" = (
 /obj/structure/table/wood,
@@ -17527,11 +19842,21 @@
 /turf/open/floor/wood/wood_common,
 /area/f13/tunnel/bighorn)
 "stF" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 6
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
 	},
-/area/f13/brotherhood/armory)
+/obj/structure/chair/bench{
+	pixel_y = 15
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
+"stH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood)
 "stX" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
@@ -17548,29 +19873,44 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"svq" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "QMLoad"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/closet/crate/science,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
 "svy" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/museum)
 "sxz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "0-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/turf/open/floor/mineral/plastitanium,
 /area/f13/brotherhood)
 "sxY" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/tunnel/bighorn)
 "syK" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/bunker/glass,
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "sza" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -17581,13 +19921,16 @@
 	},
 /area/f13/tunnel)
 "szm" = (
-/obj/structure/bed/dogbed,
-/mob/living/simple_animal/pet/dog/pug{
-	desc = "A pug handed down through many generations.";
-	name = "Paladin Ramos"
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 6
 	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "szv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -17599,16 +19942,30 @@
 	},
 /area/f13/tunnel)
 "szF" = (
-/obj/item/am_shielding_container,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/reactor)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "sAM" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/machinery/light/small{
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/dorms)
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/turf/open/water,
+/area/f13/brotherhood)
 "sAR" = (
 /obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt,
@@ -17627,19 +19984,18 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/followers)
-"sBv" = (
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/under/f13/bosformgold_f,
-/obj/item/clothing/under/f13/bosformgold_m,
-/obj/structure/closet,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/soap,
-/obj/item/storage/box/fountainpens,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 4
+"sBc" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/area/f13/brotherhood/archives)
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood)
+"sBv" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "sBz" = (
 /obj/structure/simple_door/wood{
 	name = "Bighorn Residence"
@@ -17661,24 +20017,27 @@
 /turf/open/floor/plasteel/darkred/side,
 /area/f13/brotherhood)
 "sEa" = (
-/obj/machinery/workbench,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side,
-/area/f13/brotherhood/armory)
+/obj/machinery/mech_bay_recharge_port,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
 "sEc" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault/side,
+/turf/open/water,
 /area/f13/brotherhood)
 "sEK" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/east,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault/side{
-	dir = 1
+/obj/machinery/button/door{
+	id = "boscheckpoint";
+	name = "Research Checkpoint Button";
+	pixel_x = -32
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "sGa" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17712,13 +20071,23 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel/bighorn)
-"sHA" = (
-/obj/structure/bed,
-/obj/item/bedsheet/grey,
-/obj/effect/landmark/start/f13/seniorscribe,
+"sHl" = (
+/obj/machinery/chem_dispenser/drinks{
+	dir = 1;
+	pixel_y = -1
+	},
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/brotherhood)
+"sHA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/wardrobe/robo_wardrobe,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "sIk" = (
 /obj/structure/sink{
 	pixel_y = 19
@@ -17736,16 +20105,22 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "sIH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/lattice{
+	density = 1
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = -12
 	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
+/obj/structure/fence/handrail_corner{
+	density = 0;
+	dir = 8;
+	layer = 4.2;
+	pixel_x = -12;
+	pixel_y = 16
 	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "sJj" = (
 /obj/machinery/light/fo13colored/Pink{
@@ -17755,6 +20130,18 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
+"sJU" = (
+/obj/structure/closet,
+/obj/item/mining_scanner,
+/obj/item/clothing/glasses/meson,
+/obj/item/pickaxe/drill,
+/obj/machinery/camera/autoname{
+	dir = 6;
+	name = "South Facing Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/brotherhood)
 "sKa" = (
 /obj/item/mine/explosive,
 /turf/open/indestructible/ground/inside/mountain,
@@ -17780,18 +20167,37 @@
 	},
 /area/f13/tunnel/bighorn)
 "sLQ" = (
-/obj/structure/target_stake,
-/obj/structure/window/reinforced/spawner/north{
-	dir = 4
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/item/target,
-/turf/open/floor/f13,
-/area/f13/brotherhood/armory)
-"sLV" = (
-/obj/effect/landmark/start/f13/Knight,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/armory)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/security/bos{
+	circuit = /obj/item/circuitboard/computer/security;
+	dir = 8;
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/machinery/computer/terminal{
+	dir = 8;
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood)
+"sLV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/landmark/start/f13/Knight,
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood)
 "sLZ" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
 	dir = 4;
@@ -17811,30 +20217,53 @@
 	},
 /area/f13/tunnel)
 "sMy" = (
-/obj/structure/closet/crate/bin{
-	density = 0;
-	pixel_y = 21
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "sMO" = (
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault/side{
-	dir = 6
+/obj/structure/bed/pod,
+/obj/item/bedsheet/rd{
+	desc = "A fine quilted blanket, made with purple and yellow fabric.";
+	dream_messages = list("authority","a                                                                silvery                                                                ID","a                                                                bomb","a                                                                mech","a                                                                facehugger","maniacal                                                                laughter");
+	name = "fine bedsheet"
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "sMP" = (
-/obj/machinery/computer/operating/bos,
-/turf/open/floor/plasteel/freezer,
-/area/f13/brotherhood/medical)
-"sNC" = (
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 5
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/area/f13/brotherhood/archives)
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood)
+"sNC" = (
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
+	},
+/turf/open/water,
+/area/f13/brotherhood)
 "sOr" = (
 /obj/item/storage/trash_stack,
 /obj/item/mine/explosive,
@@ -17846,6 +20275,19 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
+"sQq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "sQv" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress3"
@@ -17859,10 +20301,16 @@
 	},
 /area/f13/tunnel)
 "sQF" = (
-/obj/structure/railing{
-	dir = 6
+/obj/machinery/conveyor/inverted{
+	dir = 8;
+	id = "garbage"
 	},
-/turf/closed/wall/r_wall/f13/vault,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/brotherhood)
 "sRk" = (
 /obj/structure/rack,
@@ -17870,10 +20318,25 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "sSo" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 5
+/turf/open/water,
+/area/f13/brotherhood)
+"sSG" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/table/reinforced,
+/obj/item/kitchen/rollingpin,
+/obj/item/kitchen/knife/butcher,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/camera/autoname{
+	dir = 6;
+	name = "South Facing Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhdirty_chess2"
 	},
 /area/f13/brotherhood)
 "sTj" = (
@@ -17892,18 +20355,20 @@
 	},
 /area/f13/tunnel)
 "sUJ" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
-"sVa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
-	dir = 8;
-	name = "prewar lounge chair"
+/obj/structure/bookcase/random/religion{
+	density = 0;
+	layer = 2.8;
+	pixel_y = 23
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
+"sVa" = (
+/obj/structure/bed/dogbed,
+/mob/living/simple_animal/pet/dog/pug{
+	name = "Paladin Wimbleton"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "sVr" = (
 /obj/machinery/light/fo13colored/Aqua{
 	dir = 1;
@@ -17933,37 +20398,37 @@
 	},
 /area/f13/tunnel/bighorn)
 "sWg" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/west,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault/side{
-	dir = 8
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood)
 "sWt" = (
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "sXj" = (
-/obj/machinery/door/airlock/hatch{
-	id_tag = "librarians2";
-	name = "Librarian's Office";
-	req_access_txt = "120"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
-"sXE" = (
-/obj/machinery/sleeper{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "white"
-	},
-/area/f13/brotherhood/medical)
-"sZn" = (
-/obj/machinery/flasher/portable,
-/obj/effect/turf_decal/box,
+/obj/machinery/vending/cigarette/syndicate,
 /turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
+"sXE" = (
+/obj/structure/table/wood,
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
+"sZn" = (
+/obj/structure/simple_door/bunker/glass,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
+	},
 /area/f13/brotherhood)
 "sZs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17986,38 +20451,53 @@
 /area/f13/tunnel/bighorn)
 "tau" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 8
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "taI" = (
-/obj/machinery/door/airlock/hatch{
-	id_tag = "Marshal2";
-	name = "Marshal Office";
-	req_access_txt = "120"
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "tbd" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/museum)
+"tbp" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/computer/rdconsole/core/bos{
+	dir = 4;
+	icon_keyboard = "terminal_key";
+	icon_screen = "terminal_on_alt";
+	icon_state = "terminal"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "tbr" = (
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building/massfusion)
 "tbI" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/hatch{
-	id_tag = "knightca1";
-	name = "Knight Captain's Office";
-	req_access_txt = "120"
+/obj/structure/table/optable,
+/obj/machinery/iv_drip{
+	pixel_x = 15;
+	pixel_y = -2
 	},
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/offices1st)
+/obj/machinery/camera/autoname{
+	dir = 6;
+	name = "South Facing Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "tbQ" = (
 /obj/structure/closet/crate,
 /obj/item/clothing/suit/armor/f13/power_armor/t45d,
@@ -18038,6 +20518,27 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"tcz" = (
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/grassybush{
+	layer = 2.1
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/turf/open/water,
+/area/f13/brotherhood)
 "tcI" = (
 /obj/machinery/door/unpowered/securedoor/bank_door,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -18057,12 +20558,28 @@
 	},
 /area/f13/tunnel)
 "tex" = (
-/obj/machinery/computer/card/bos,
-/obj/item/card/id/dogtag,
-/obj/item/card/id/dogtag,
-/obj/item/card/id/dogtag,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/ausbushes/grassybush{
+	layer = 2.1
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/turf/open/water,
+/area/f13/brotherhood)
 "teF" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
@@ -18072,21 +20589,27 @@
 	},
 /area/f13/tunnel)
 "teH" = (
-/obj/structure/table/optable,
-/turf/open/floor/plasteel/freezer,
-/area/f13/brotherhood/medical)
+/obj/structure/table,
+/obj/item/storage/box/drinkingglasses{
+	pixel_y = 2
+	},
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/brotherhood)
 "teK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "tfh" = (
-/obj/structure/table/glass,
-/obj/item/paper_bin,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/item/flag/bos,
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/archives)
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood)
 "tfn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/mattress{
@@ -18097,10 +20620,27 @@
 	},
 /area/f13/tunnel)
 "tgR" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
+	},
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
+	},
+/turf/open/water,
+/area/f13/brotherhood)
 "tha" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
@@ -18116,8 +20656,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "thB" = (
-/turf/open/floor/f13,
-/area/f13/brotherhood/armory)
+/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood)
 "tit" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -18142,16 +20686,17 @@
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "tjj" = (
-/obj/effect/turf_decal/caution{
-	dir = 4
+/obj/structure/lattice{
+	layer = 3
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/item/cigbutt{
+	anchored = 1;
+	color = "#808080";
+	layer = 2;
+	pixel_x = -4;
+	pixel_y = 1
 	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "QMUnload"
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "tjz" = (
 /obj/structure/sink{
@@ -18177,16 +20722,30 @@
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"tlN" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 10;
+	pixel_x = 7
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/structure/chair/bench{
+	pixel_y = 15
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "tnm" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_y = 12;
+	pixel_x = -11
 	},
-/obj/structure/closet/locker,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_y = 12
 	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "tnC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -18210,16 +20769,12 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "tpb" = (
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'SECURE AREA: POWER ARMOR STORAGE'."
-	},
-/turf/closed/indestructible/vaultdoor{
-	desc = "A wall built to withstand an atomic explosion.";
-	icon = 'icons/fallout/turfs/walls/vault_reinforced.dmi';
-	icon_state = "vaultrwall0";
-	icon_type_smooth = "vaultrwall";
-	name = "vault reinforced wall"
-	},
+/obj/item/clothing/suit/toggle/labcoat/scribecoat,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/suit/toggle/labcoat/scribecoat,
+/obj/structure/table/survival_pod,
+/turf/open/floor/plasteel/darkpurple,
 /area/f13/brotherhood)
 "tpc" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
@@ -18252,8 +20807,13 @@
 /turf/closed/wall/rust,
 /area/f13/tunnel/bighorn)
 "tsi" = (
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/brotherhood/medical)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood)
 "tso" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf_metal,
@@ -18261,43 +20821,30 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "tsu" = (
-/obj/structure/table/reinforced,
-/obj/item/flashlight/lamp,
-/obj/machinery/button/door{
-	id = "knightc1";
-	name = "Knight-commanders office";
-	normaldoorcontrol = 1;
-	req_access_txt = "120";
-	specialfunctions = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/machinery/door/window/left/directional/north,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood)
 "tsF" = (
 /obj/structure/nest/scorpion,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "tsK" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "QMLoad"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood)
-"tsV" = (
-/obj/machinery/door/window/right{
-	dir = 1;
-	req_one_access_txt = "120"
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 9
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
+"tsV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet,
+/area/f13/brotherhood)
 "ttq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor/inverted,
@@ -18361,8 +20908,8 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "twZ" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -18426,13 +20973,29 @@
 /obj/structure/table,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"tGp" = (
-/obj/machinery/door/airlock/hatch{
-	id_tag = "scribes2";
-	name = "Scribe Quarters"
+"tEu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/dorms)
+/area/f13/brotherhood)
+"tGl" = (
+/obj/machinery/button/door{
+	id = "bosdorm7";
+	normaldoorcontrol = 1;
+	pixel_x = 28;
+	specialfunctions = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
+"tGp" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/burger/baconburger,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
 "tGO" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -18454,9 +21017,21 @@
 	},
 /area/f13/tunnel)
 "tHm" = (
-/obj/effect/landmark/start/f13/scribe,
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/archives)
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/brotherhood)
 "tHF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
@@ -18505,30 +21080,43 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel/bighorn)
 "tLt" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "white"
-	},
-/area/f13/brotherhood/medical)
-"tMu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "knightca2";
-	name = "Knight-captain's room";
-	normaldoorcontrol = 1;
-	pixel_x = -32;
-	req_access_txt = "120";
-	specialfunctions = 4
+	icon_state = "1-8"
 	},
 /turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
+"tMu" = (
+/obj/structure/decoration/hatch{
+	dir = 8
+	},
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -13
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
+	},
+/area/f13/brotherhood)
+"tMX" = (
+/obj/structure/closet/crate/bin{
+	anchorable = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/brotherhood)
 "tNq" = (
-/obj/structure/mirror,
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/brotherhood/offices1st)
+/obj/structure/bookcase/random/reference{
+	desc = "A collection of scrolls, archives and relics.";
+	name = "Archival References"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood)
 "tNx" = (
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/floor/plating,
@@ -18544,16 +21132,11 @@
 	},
 /area/f13/tunnel)
 "tOy" = (
-/obj/structure/chair{
-	dir = 8
+/obj/structure/statue/bos/ladyleft{
+	pixel_y = 10
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 4
-	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plating/dirt/dark,
 /area/f13/brotherhood)
 "tPC" = (
 /obj/structure/wreck/trash/five_tires{
@@ -18569,6 +21152,11 @@
 /area/f13/tunnel/bighorn)
 "tRK" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname{
+	dir = 6;
+	name = "South Facing Camera";
+	network = list("BoS")
+	},
 /turf/open/floor/plasteel/darkred/side{
 	dir = 5
 	},
@@ -18588,15 +21176,18 @@
 /area/f13/tunnel/bighorn)
 "tTa" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault/corner{
-	dir = 4
-	},
+/obj/structure/weightmachine/stacklifter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood)
 "tTH" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/item/cigbutt/cigarbutt,
+/obj/effect/decal/cleanable/ash/snappop_phoenix,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "tTY" = (
 /obj/structure/toilet{
@@ -18632,14 +21223,15 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/building/museum)
 "tWa" = (
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/brotherhood/dorms)
+/obj/structure/chair/bench,
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "tWe" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/light_emitter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "tWi" = (
 /obj/item/shield/riot,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
@@ -18672,19 +21264,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/building/museum)
 "tZW" = (
-/obj/structure/closet/toolcloset,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "uab" = (
-/obj/machinery/light,
-/obj/structure/closet/crate/medical,
-/obj/effect/turf_decal/bot_red,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side,
-/area/f13/brotherhood/armory)
+/obj/structure/rack,
+/obj/item/shield/riot/bullet_proof,
+/obj/item/shield/riot/bullet_proof,
+/obj/item/pda{
+	icon_state = "pda-warden";
+	name = "Armory Warden PDA"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "uap" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/darkpurple/side{
@@ -18705,17 +21298,25 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel/bighorn)
 "ubO" = (
-/obj/effect/landmark/start/f13/paladin,
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "120"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood)
 "udp" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "white"
+	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "ueb" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/turf_decal/weather/dirt{
@@ -18726,18 +21327,37 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"ues" = (
+/obj/machinery/camera/autoname{
+	dir = 6;
+	name = "South Facing Camera";
+	network = list("BoS")
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
 "ueK" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/structure/table/wood/settler,
+/obj/item/storage/box/drinkingglasses,
 /turf/open/floor/f13{
-	icon_state = "white"
+	icon_state = "reddirtyfull"
 	},
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "ufI" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
+"ufL" = (
+/obj/machinery/vending/robotics{
+	force_free = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood)
 "ufM" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
@@ -18745,6 +21365,10 @@
 	icon_state = "neutralrusty"
 	},
 /area/f13/tunnel)
+"ugu" = (
+/obj/structure/weightmachine/stacklifter,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "ugv" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/drone,
@@ -18799,6 +21423,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/building/museum)
+"ukZ" = (
+/obj/structure/stairs/west,
+/turf/open/transparent/openspace,
+/area/f13/brotherhood)
 "uln" = (
 /obj/machinery/light/fo13colored/Red{
 	dir = 1;
@@ -18817,20 +21445,22 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
+"umJ" = (
+/obj/machinery/conveyor/inverted{
+	dir = 10;
+	id = "garbage"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
 "unv" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "twindowold"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1{
+	icon_state = "casino"
 	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "twindowold"
-	},
-/obj/structure/rack,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 5
-	},
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "unL" = (
 /obj/structure/nest/ghoul,
 /turf/open/floor/plasteel/f13{
@@ -18848,12 +21478,20 @@
 	},
 /area/f13/tunnel)
 "uqG" = (
-/obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/item/clothing/gloves/color/latex/nitrile,
-/obj/item/detective_scanner,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/brotherhood/medical)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/button/door{
+	id = "bosengineaccessrear";
+	name = "Engineering Lockdown";
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "urc" = (
 /obj/structure/campfire/barrel,
 /turf/open/floor/f13{
@@ -18865,18 +21503,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "utv" = (
-/obj/structure/bed,
-/obj/item/bedsheet/black,
-/obj/machinery/button/door{
-	id = "paladins2";
-	name = "Paladin Room 2";
-	normaldoorcontrol = 1;
-	pixel_x = 32;
-	req_access_txt = "120";
-	specialfunctions = 4
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/dorms)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "utC" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -18885,6 +21520,16 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"utQ" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/obj/item/stock_parts/cell/super,
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "uuJ" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -18912,15 +21557,15 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/followers)
 "uvy" = (
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool,
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
 	},
-/obj/machinery/power/port_gen/pacman/super{
-	anchored = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/carpet/purple,
+/area/f13/brotherhood)
 "uvM" = (
 /obj/structure/ladder/unbreakable{
 	id = "bheastladder"
@@ -18929,12 +21574,22 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel/bighorn)
-"uwS" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/mineral/uranium{
-	amount = 50
+"uwD" = (
+/obj/structure/bookcase/random/religion{
+	desc = "A collection of scrolls, archives and relics.";
+	name = "Religious References"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood)
+"uwS" = (
+/obj/structure/chair/comfy{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/purple,
 /area/f13/brotherhood)
 "uwX" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -18966,14 +21621,24 @@
 	},
 /area/f13/clinic)
 "uyb" = (
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/brotherhood/offices1st)
-"uyj" = (
-/obj/structure/curtain{
-	pixel_y = -32
+/obj/structure/lattice{
+	density = 1
 	},
-/turf/open/floor/plasteel/freezer,
-/area/f13/brotherhood/medical)
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 1;
+	pixel_y = -9
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
+"uyj" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "bosengine"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood)
 "uyq" = (
 /obj/item/reagent_containers/glass/bucket{
 	desc = "It smells awful.";
@@ -19035,13 +21700,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/museum)
 "uBR" = (
-/obj/item/twohanded/sledgehammer/supersledge,
-/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 8
-	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
 "uDF" = (
 /obj/effect/turf_decal/bot_red,
 /mob/living/simple_animal/hostile/securitron/sentrybot,
@@ -19056,6 +21717,16 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel/bighorn)
+"uEA" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/storage/box/cups{
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "uFz" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Clinic Research";
@@ -19076,14 +21747,15 @@
 	},
 /area/f13/tunnel)
 "uGa" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/hatch{
-	id_tag = "knightc1";
-	name = "Knight-Commander Office";
-	req_access_txt = "120"
+/obj/structure/toilet{
+	pixel_y = 10
 	},
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/offices1st)
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_x = -10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood)
 "uHa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -19172,33 +21844,31 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "uPJ" = (
-/obj/structure/closet/crate/secure/weapon{
-	anchored = 1
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/item/grenade/barrier,
-/obj/item/grenade/barrier,
-/obj/item/grenade/barrier,
-/obj/item/grenade/flashbang,
-/obj/item/grenade/flashbang,
-/obj/item/grenade/chem_grenade/teargas,
-/obj/effect/turf_decal/bot_red,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/corner,
-/area/f13/brotherhood/armory)
+/obj/machinery/computer/terminal{
+	dir = 4;
+	pixel_y = -6;
+	termtag = "Secret"
+	},
+/obj/machinery/computer/security/bos{
+	circuit = /obj/item/circuitboard/computer/security;
+	dir = 4;
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "uQM" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/brotherhood)
 "uQV" = (
-/obj/structure/frame/computer{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "uRc" = (
 /mob/living/simple_animal/hostile/raider/ranged{
 	name = "Tunnel Torturers Raider"
@@ -19221,24 +21891,15 @@
 	},
 /area/f13/bunker)
 "uUY" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner,
-/obj/structure/table/reinforced,
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/brigdoor{
-	dir = 8;
-	req_access_txt = "255"
-	},
-/obj/effect/spawner/lootdrop/f13/armor/bos_vault,
-/turf/open/floor/plasteel/vault/side{
-	dir = 8
-	},
+/obj/structure/junk/small/tv,
+/obj/structure/table/wood/settler,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "uWb" = (
-/turf/open/floor/plasteel/darkpurple/side,
-/area/f13/brotherhood/archives)
+/obj/structure/table/glass,
+/obj/machinery/chem_heater,
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "uWk" = (
 /obj/structure/junk/machinery,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -19248,15 +21909,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "uWI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
+/obj/structure/lattice{
+	layer = 3
 	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "uXp" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -19293,11 +21953,17 @@
 	},
 /area/f13/building/massfusion)
 "uYW" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/stripes/red/line{
 	dir = 8
 	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/dorms)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
 "vas" = (
 /obj/structure/simple_door/wood{
 	name = "Bighorn Residence"
@@ -19305,8 +21971,19 @@
 /turf/open/floor/wood/wood_common,
 /area/f13/tunnel/bighorn)
 "vaL" = (
-/turf/open/floor/plasteel/vault/side{
-	dir = 1
+/obj/structure/chair/stool/retro/black,
+/obj/machinery/light/small,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
+	},
+/obj/structure/cable,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
 /area/f13/brotherhood)
 "vbg" = (
@@ -19323,24 +22000,25 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "vca" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
+"vcF" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_x = 32;
+	start_charge = 500
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/darkred/corner{
-	dir = 8
-	},
-/area/f13/brotherhood/armory)
-"vcF" = (
-/obj/machinery/door/window/brigdoor{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/armory)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "vdg" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -19358,14 +22036,8 @@
 	},
 /area/f13/tunnel/bighorn)
 "vdQ" = (
-/obj/machinery/mineral/equipment_vendor{
-	density = 0;
-	pixel_y = 22
-	},
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
-	},
-/area/f13/brotherhood/archives)
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "vdS" = (
 /obj/effect/turf_decal/stripes/white/corner{
 	dir = 4
@@ -19381,13 +22053,9 @@
 /turf/open/floor/wood/wood_common,
 /area/f13/tunnel/bighorn)
 "vef" = (
-/obj/structure/sink{
-	pixel_y = 19
-	},
-/turf/open/floor/f13{
-	icon_state = "white"
-	},
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13/vault,
+/area/f13/brotherhood)
 "vei" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/f13{
@@ -19401,9 +22069,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel/bighorn)
 "vfZ" = (
-/obj/structure/chair/sofa/corp/right,
+/obj/structure/table/abductor{
+	name = "Advanced Polymer Table";
+	desc = "An advanced design made from plasma and steel alloys made by Keeper Eastlyn Dauntz."
+	},
 /turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "vgh" = (
 /obj/structure/railing{
 	dir = 9
@@ -19451,12 +22122,15 @@
 	},
 /area/f13/tunnel)
 "vhO" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/west,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault/side{
-	dir = 1
+/obj/structure/table/wood/fancy/black,
+/obj/item/pda/heads/cmo{
+	name = "Head Scribe PipBoy"
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "vhZ" = (
 /obj/structure/chair/booth{
@@ -19521,18 +22195,17 @@
 	},
 /area/f13/tunnel/bighorn)
 "vmp" = (
-/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
-	},
-/area/f13/brotherhood/armory)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
 "vnv" = (
-/obj/item/wrench,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/brotherhood/reactor)
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "vnC" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib5-old"
@@ -19550,9 +22223,15 @@
 /turf/open/floor/wood/wood_common,
 /area/f13/tunnel/bighorn)
 "voJ" = (
-/obj/structure/dresser,
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "vqE" = (
 /obj/structure/toilet{
 	dir = 1
@@ -19560,6 +22239,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel/bighorn)
+"vqM" = (
+/obj/effect/turf_decal/box,
+/obj/effect/spawner/lootdrop/crate_spawner,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
+"vsR" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "vts" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -19569,11 +22259,15 @@
 	},
 /area/f13/bunker)
 "vuj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = 4
 	},
-/turf/open/floor/plasteel/darkred/side,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
 /area/f13/brotherhood)
 "vuI" = (
 /obj/effect/landmark/start/f13/followersguard,
@@ -19598,19 +22292,24 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/building/museum)
 "vwE" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 8
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "120"
 	},
-/area/f13/brotherhood/armory)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
 "vwJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/building/museum)
 "vxi" = (
-/obj/structure/sign/departments/security,
-/turf/closed/wall/r_wall/f13/vault,
+/obj/machinery/chem_master/advanced,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "vxI" = (
 /obj/machinery/light/small{
@@ -19627,13 +22326,25 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel/bighorn)
+"vxO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/storage/fancy/cigarettes/cigars{
+	pixel_y = 4
+	},
+/turf/open/floor/carpet/purple,
+/area/f13/brotherhood)
 "vzF" = (
 /obj/machinery/photocopier,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "vzK" = (
-/turf/open/floor/plasteel/freezer,
-/area/f13/brotherhood/medical)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood)
 "vzO" = (
 /obj/item/stack/sheet/mineral/uranium,
 /obj/effect/decal/cleanable/generic,
@@ -19668,10 +22379,24 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/massfusion)
 "vBu" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 3
+	},
+/turf/open/water,
+/area/f13/brotherhood)
+"vCA" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
 /area/f13/brotherhood)
 "vCM" = (
 /obj/structure/bed/pod,
@@ -19702,9 +22427,14 @@
 	},
 /area/f13/tunnel)
 "vFe" = (
-/obj/structure/chair/sofa/corp,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/dorms)
+/obj/machinery/camera/autoname{
+	dir = 6;
+	name = "South Facing Camera";
+	network = list("BoS")
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "vFL" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -19712,15 +22442,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vGf" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/machinery/camera/autoname{
+	dir = 6;
+	name = "South Facing Camera";
+	network = list("BoS")
 	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 8
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood)
 "vGl" = (
@@ -19787,9 +22518,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "vKT" = (
-/obj/machinery/light,
-/turf/open/floor/f13,
-/area/f13/brotherhood/armory)
+/obj/item/paper/crumpled/ruins,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood)
 "vKY" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -19831,12 +22568,14 @@
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "vNK" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowtop"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood)
 "vNL" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -19867,12 +22606,21 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
-"vOB" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 8
+"vOn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
+"vOB" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood)
 "vPk" = (
 /obj/effect/turf_decal/stripes/white/corner{
 	dir = 8
@@ -19910,6 +22658,13 @@
 /mob/living/simple_animal/hostile/giantantqueen,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"vQy" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "vRA" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_south_middle"
@@ -19984,45 +22739,46 @@
 	pixel_y = 1
 	},
 /obj/machinery/light,
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
+	},
 /turf/open/floor/plasteel/darkred/side{
 	dir = 6
 	},
 /area/f13/brotherhood)
 "vWk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/toilet{
-	dir = 1;
-	pixel_y = -1
-	},
 /turf/open/floor/f13{
-	icon_state = "white"
+	icon_state = "bluerustysolid"
 	},
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "vWC" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/circuitboard/machine/bloodbankgen,
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "vXs" = (
-/obj/machinery/washing_machine,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = -32
 	},
-/area/f13/brotherhood/leisure)
+/obj/structure/chair/sofa/corp/right{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood)
 "vXx" = (
-/obj/item/clothing/under/f13/bosform_f,
-/obj/item/clothing/under/f13/bosform_f,
-/obj/item/clothing/under/f13/bosform_f,
-/obj/item/clothing/under/f13/bosform_m,
-/obj/item/clothing/under/f13/bosform_m,
-/obj/item/clothing/under/f13/bosform_m,
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
-	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 8
-	},
-/area/f13/brotherhood/armory)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/bench,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "vYx" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore"
@@ -20032,9 +22788,10 @@
 	},
 /area/f13/tunnel)
 "vYD" = (
-/obj/item/flag/bos,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault/side,
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood)
 "vYI" = (
 /obj/structure/barricade/wooden,
@@ -20049,8 +22806,13 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "vZh" = (
-/obj/machinery/mineral/wasteland_vendor/weapons/BoS,
-/turf/open/floor/plasteel/dark,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/brotherhood)
 "vZV" = (
 /obj/structure/table/wood/settler,
@@ -20061,8 +22823,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "waO" = (
 /mob/living/simple_animal/hostile/raider/ranged/boss{
 	name = "Tunnel Torturers Boss"
@@ -20080,10 +22842,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "wce" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault/side{
-	dir = 4
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "wdq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20110,13 +22877,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "weG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/caution/stand_clear{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/closet/crate/wooden,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood)
 "weO" = (
 /obj/structure/sign/poster/contraband/pinup_topless{
@@ -20176,10 +22940,10 @@
 	},
 /area/f13/tunnel/bighorn)
 "wjq" = (
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
-	},
-/area/f13/brotherhood/archives)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "wlv" = (
 /obj/item/bighorn_flag,
 /turf/open/floor/f13/wood,
@@ -20197,12 +22961,12 @@
 /area/f13/building/massfusion)
 "wlK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/dresser{
-	density = 0;
-	pixel_y = 20
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "wlS" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
@@ -20233,6 +22997,15 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"wmQ" = (
+/obj/machinery/computer/auxillary_base{
+	pixel_y = -34
+	},
+/obj/structure/chair/sofa/corp/corner{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "woc" = (
 /mob/living/simple_animal/hostile/raider/ranged/biker{
 	name = "Tunnel Torturers Raider"
@@ -20242,10 +23015,11 @@
 	},
 /area/f13/tunnel)
 "wpg" = (
-/obj/structure/chair/sofa/corp/right,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/dorms)
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood)
 "wpZ" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -20261,12 +23035,33 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"wqS" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/machinery/camera/autoname{
+	dir = 8;
+	name = "Armory Camera";
+	network = list("BoS");
+	pixel_x = -1
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "wrE" = (
 /obj/structure/bed/pod,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/museum)
 "wrP" = (
 /obj/machinery/light,
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
+	},
 /turf/open/floor/plasteel/darkred/side,
 /area/f13/brotherhood)
 "wsg" = (
@@ -20274,11 +23069,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "wsK" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/window/fulltile/store,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/brotherhood)
 "wsL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20295,14 +23092,26 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building/museum)
 "wtC" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/circuitboard/machine/bloodbankgen,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "wtQ" = (
-/obj/structure/stairs/east,
-/turf/open/floor/plasteel/vault/side{
-	dir = 1
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood)
 "wtX" = (
@@ -20335,15 +23144,11 @@
 	},
 /area/f13/tunnel/bighorn)
 "wwj" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
 "wwt" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -20361,13 +23166,7 @@
 /turf/open/floor/plating,
 /area/f13/building/museum)
 "wwI" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/structure/window/fulltile/store,
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "wxX" = (
@@ -20384,6 +23183,25 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/tunnel)
+"wAJ" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/sign/poster/contraband/tools{
+	pixel_y = 31
+	},
+/obj/machinery/camera/autoname{
+	dir = 6;
+	name = "South Facing Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood)
 "wBc" = (
 /obj/structure/rack/shelf_metal,
 /obj/structure/window/reinforced/spawner{
@@ -20399,31 +23217,57 @@
 	},
 /area/f13/followers)
 "wBd" = (
-/obj/structure/grille,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plasteel/dark,
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
 /area/f13/brotherhood)
 "wBj" = (
-/obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/hatch{
-	name = "Research";
 	req_access_txt = "120"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/darkpurple,
-/area/f13/brotherhood/archives)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "wCO" = (
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel/bighorn)
 "wDj" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = -32
 	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
+"wEv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 10;
+	pixel_x = -4
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_midori{
+	pixel_y = 5;
+	pixel_x = 8
+	},
+/turf/open/floor/carpet/purple,
+/area/f13/brotherhood)
 "wEW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains{
@@ -20442,9 +23286,11 @@
 	},
 /area/f13/followers)
 "wFn" = (
-/obj/effect/turf_decal/box,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhdirty_chess2"
+	},
 /area/f13/brotherhood)
 "wGI" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -20476,12 +23322,10 @@
 	},
 /area/f13/followers)
 "wHD" = (
-/obj/structure/bed,
-/obj/item/bedsheet/grey,
-/obj/effect/landmark/start/f13/knightcap,
-/obj/item/toy/plush/lizardplushie,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
 "wIn" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -20500,15 +23344,22 @@
 /turf/open/floor/wood/wood_common,
 /area/f13/tunnel/bighorn)
 "wJa" = (
-/obj/structure/sign/departments/security,
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/brotherhood/armory)
-"wKh" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/target_stake{
+	anchored = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/brotherhood/reactor)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
+"wKh" = (
+/obj/structure/chair/bench,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "wKP" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -20525,17 +23376,22 @@
 	},
 /area/f13/tunnel)
 "wLq" = (
-/obj/structure/table/reinforced,
-/obj/item/flashlight/lamp,
-/obj/machinery/button/door{
-	id = "knightca1";
-	name = "Knight Captain's Office";
-	normaldoorcontrol = 1;
-	req_access_txt = "120";
-	specialfunctions = 4
+/obj/structure/noticeboard{
+	name = "display plate";
+	pixel_x = 16;
+	pixel_y = 34
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/item/gun/energy/laser/plasma/scatter{
+	anchored = 1;
+	cell_type = null;
+	desc = "A modified A3-20 plasma caster built by REPCONN equipped with a multicasting kit that creates multiple weaker clots. This one is for display, and no longer fires.";
+	name = "display multiplas rifle";
+	pin = null;
+	pixel_x = 16;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "wLH" = (
 /obj/structure/closet/fridge,
 /obj/item/storage/fancy/egg_box,
@@ -20561,20 +23417,47 @@
 "wMj" = (
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
-"wNE" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/darkred/side{
+"wMy" = (
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/obj/structure/flora/junglebush{
+	pixel_x = -15
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
 	dir = 4
 	},
-/area/f13/brotherhood/armory)
-"wNJ" = (
-/obj/machinery/door/airlock/hatch{
-	id_tag = "paladins2";
-	name = "Paladin Room 2";
-	req_access_txt = "120"
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
 	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/dorms)
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/turf/open/water,
+/area/f13/brotherhood)
+"wNE" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
+"wNJ" = (
+/obj/machinery/conveyor/inverted,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "wNV" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/blueprintMid,
@@ -20588,25 +23471,33 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
 "wOH" = (
+/obj/structure/table,
+/obj/machinery/recharger,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "wQJ" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
 	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 4
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood)
 "wQZ" = (
@@ -20633,14 +23524,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/museum)
 "wTx" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Recovery Ward";
-	req_access_txt = "120"
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/f13{
-	icon_state = "white"
-	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "wUD" = (
 /obj/structure/chair/left{
 	dir = 1
@@ -20650,27 +23538,50 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building/museum)
 "wUI" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/darkred/corner{
-	dir = 1
+/obj/structure/rack,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood)
 "wUV" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "wVL" = (
-/obj/machinery/autolathe/constructionlathe,
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
 /obj/structure/window/reinforced{
-	dir = 1
+	color = "#3e3d42";
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
+/obj/structure/flora/ausbushes/grassybush{
+	layer = 2.1
 	},
-/area/f13/brotherhood/armory)
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/turf/open/water,
+/area/f13/brotherhood)
 "wVM" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -20678,14 +23589,10 @@
 	},
 /area/f13/tunnel)
 "wWo" = (
-/obj/machinery/chem_dispenser/drinks{
-	density = 0;
-	dir = 1;
-	pixel_y = -15
-	},
+/obj/structure/weightmachine/weightlifter,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "wWp" = (
 /obj/structure/girder,
 /obj/structure/barricade/wooden/planks,
@@ -20717,10 +23624,8 @@
 	},
 /area/f13/caves)
 "wZq" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 10
-	},
+/obj/structure/dresser,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "wZt" = (
 /obj/structure/table/booth,
@@ -20735,16 +23640,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "xab" = (
-/obj/machinery/shower{
-	pixel_y = 27
-	},
-/obj/structure/curtain,
-/obj/item/soap,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "white"
-	},
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
 "xaC" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -20767,16 +23664,17 @@
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
 "xdR" = (
-/obj/structure/chair/sofa/corp{
-	dir = 8
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "xeo" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side,
-/area/f13/brotherhood/armory)
+/obj/structure/barricade/bars,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood)
 "xeF" = (
 /obj/machinery/shower{
 	dir = 4
@@ -20840,23 +23738,32 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel/bighorn)
 "xiQ" = (
-/obj/structure/closet/crate/wooden,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/brotherhood)
 "xjH" = (
-/turf/open/floor/plasteel/darkred/corner{
-	dir = 8
-	},
-/area/f13/brotherhood/armory)
-"xjW" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
+"xjW" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "xkt" = (
 /obj/structure/barricade/sandbags,
 /obj/machinery/light/small{
@@ -20870,14 +23777,10 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
 "xkz" = (
-/obj/item/twohanded/required/kirbyplants/random,
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/window/reinforced,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 6
-	},
+/turf/open/water,
 /area/f13/brotherhood)
 "xnp" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20905,9 +23808,9 @@
 /area/f13/tunnel)
 "xoI" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/turf/open/floor/mineral/plastitanium,
 /area/f13/brotherhood)
 "xqr" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20920,21 +23823,27 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/museum)
 "xrn" = (
-/obj/structure/sink{
-	pixel_y = 19
+/obj/structure/table{
+	layer = 2.9
 	},
+/obj/item/storage/firstaid/regular{
+	pixel_y = 5
+	},
+/obj/item/storage/firstaid/regular,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "white"
-	},
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "xsc" = (
-/obj/structure/bodycontainer/crematorium{
-	dir = 4;
-	id = "BOS Crematorium"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/vault{
+	name = "Engine Access";
+	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/brotherhood/medical)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood)
 "xuc" = (
 /obj/structure/sign/poster/contraband/space_cola{
 	pixel_x = -32
@@ -20944,46 +23853,35 @@
 	},
 /area/f13/followers)
 "xui" = (
-/obj/structure/curtain,
-/obj/machinery/shower{
-	dir = 1
+/obj/structure/filingcabinet,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 5
 	},
-/obj/structure/decoration/vent,
-/obj/item/soap,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "white"
+	icon_state = "reddirtyfull"
 	},
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "xum" = (
-/obj/structure/closet/crate/secure/weapon{
-	anchored = 1
-	},
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/effect/turf_decal/bot_red,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
 "xuo" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 1;
+	pixel_y = 18
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood)
 "xvv" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/f13{
@@ -20991,40 +23889,48 @@
 	},
 /area/f13/tunnel/bighorn)
 "xwg" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
+/obj/item/flag/bos{
+	pixel_x = 16
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "xwF" = (
-/obj/structure/chair/wood{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood)
+"xxf" = (
+/obj/machinery/autolathe,
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
-"xxf" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood)
 "xxp" = (
 /obj/structure/chair/wood,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "xxs" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "xxX" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel/bighorn)
@@ -21069,13 +23975,20 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"xBH" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
+"xBA" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/structure/table/wood,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood)
+"xBH" = (
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/workbench/advanced,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "xBM" = (
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -21086,18 +23999,26 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel/bighorn)
 "xCN" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
+"xDw" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
+"xDG" = (
+/obj/machinery/light/small{
+	brightness = 3;
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/brotherhood/reactor)
-"xDG" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 4
-	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "xEg" = (
 /obj/structure/simple_door/wood{
 	name = "Bighorn Residence"
@@ -21116,34 +24037,14 @@
 	},
 /area/f13/followers)
 "xEX" = (
-/obj/item/clothing/under/f13/roving,
-/obj/item/clothing/under/f13/roving,
-/obj/item/clothing/under/f13/roving,
-/obj/item/clothing/mask/gas/explorer,
-/obj/item/clothing/mask/gas/explorer,
-/obj/item/clothing/mask/gas/explorer,
-/obj/item/clothing/mask/gas/explorer,
-/obj/item/clothing/mask/gas/explorer,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/structure/closet{
-	anchored = 1;
-	name = "Disguise Closet"
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "120"
 	},
-/obj/effect/turf_decal/bot_red,
-/obj/effect/spawner/lootdrop/f13/armor/tier2,
-/obj/effect/spawner/lootdrop/f13/armor/tier2,
-/obj/effect/spawner/lootdrop/f13/armor/tier2,
-/obj/item/clothing/under/f13/keksweater,
-/obj/item/clothing/under/f13/keksweater,
-/obj/item/clothing/under/f13/keksweater,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 5
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood)
 "xHi" = (
 /turf/closed/indestructible/rock{
 	desc = "A pre-War wall made of solid concrete.";
@@ -21206,16 +24107,16 @@
 	},
 /area/f13/building/massfusion)
 "xJG" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/sofa/corp/right{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood)
 "xKw" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/structure/barricade/wooden,
@@ -21227,19 +24128,30 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/building/museum)
 "xMh" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/hatch{
-	name = "Showers";
-	req_access_txt = "120"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/area/f13/brotherhood)
 "xMo" = (
-/obj/structure/chair,
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 1;
+	pixel_y = 18
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = 13
+	},
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood)
+"xMG" = (
+/obj/structure/table/reinforced,
+/obj/item/paper,
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "xMZ" = (
@@ -21267,20 +24179,41 @@
 /obj/item/stack/f13Cash/random/denarius/high,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel/bighorn)
+"xOR" = (
+/obj/machinery/vending/tool{
+	force_free = 1
+	},
+/obj/structure/sign/poster/contraband/rip_badger{
+	pixel_x = 14;
+	pixel_y = 31
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood)
 "xPK" = (
-/obj/structure/filingcabinet/chestdrawer/wheeled,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "QMLoad"
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/area/f13/brotherhood)
 "xPV" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "xQm" = (
-/mob/living/simple_animal/pet/dog/eyebot/dense,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/chem_heater,
 /turf/open/floor/plasteel/dark,
-/area/f13/brotherhood/archives)
+/area/f13/brotherhood)
 "xRp" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -21313,17 +24246,19 @@
 	},
 /area/f13/tunnel)
 "xTo" = (
-/obj/machinery/power/terminal{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/structure/curtain{
+	color = "#5c131b"
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/brotherhood)
 "xTv" = (
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/brotherhood/reactor)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "xUA" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/handrail/g_central{
@@ -21332,23 +24267,32 @@
 /turf/open/floor/plating,
 /area/f13/tunnel)
 "xUW" = (
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/dorms)
+/obj/structure/chalkboard,
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "xVp" = (
-/obj/structure/shelf_wood,
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/regular,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "white"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood)
 "xVA" = (
-/turf/open/floor/plasteel/darkred/corner{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/twohanded/sledgehammer/supersledge,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
 	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "xVN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/asteroid/line,
@@ -21369,13 +24313,15 @@
 	},
 /area/f13/tunnel/bighorn)
 "xWy" = (
-/obj/structure/bed/pod,
-/obj/structure/curtain,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "white"
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	layer = 2.7;
+	name = "prewar lounge chair"
 	},
-/area/f13/brotherhood/medical)
+/obj/effect/landmark/start/f13/headscribe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "xWC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt,
@@ -21430,17 +24376,15 @@
 	},
 /area/f13/building/massfusion)
 "yaj" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/plasteel/grimy,
+/area/f13/brotherhood)
 "yas" = (
-/obj/machinery/light/small,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/simple_door/bunker/glass,
+/obj/structure/curtain{
+	color = "#5c131b"
 	},
-/turf/open/floor/plasteel/darkred/side,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "yau" = (
 /obj/structure/handrail/g_central{
@@ -21466,6 +24410,19 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel/bighorn)
+"ybK" = (
+/obj/machinery/rnd/server/bos,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 3
+	},
+/obj/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
 "ycl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/fridge,
@@ -21489,12 +24446,11 @@
 /area/f13/building/massfusion)
 "ydD" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 4
-	},
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood)
 "ydH" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -21523,13 +24479,23 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel/bighorn)
 "yer" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
-/turf/open/floor/plasteel/vault/corner{
-	dir = 1
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
 	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/turf/open/water,
 /area/f13/brotherhood)
 "yet" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21540,26 +24506,70 @@
 /turf/closed/wall/rust,
 /area/f13/tunnel/bighorn)
 "yfr" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/structure/rack,
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = -4;
+	pixel_y = 11
+	},
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -10;
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -6;
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -2;
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = 2;
+	pixel_y = -10
+	},
+/obj/item/storage/box/handcuffs{
+	pixel_x = 13;
+	pixel_y = -8
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/grenade/flashbang{
+	pixel_x = 9;
+	pixel_y = 8
+	},
+/obj/item/grenade/flashbang{
+	pixel_x = 11;
+	pixel_y = 8
+	},
+/obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "yfD" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple,
+/area/f13/brotherhood)
+"yfV" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood)
 "ygA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -21573,19 +24583,24 @@
 	},
 /area/f13/building/massfusion)
 "ygU" = (
-/turf/open/floor/plasteel/darkpurple/side,
+/obj/structure/simple_door/bunker/glass,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
 "yhd" = (
-/obj/item/electropack/shockcollar,
-/obj/item/electropack/shockcollar,
-/obj/item/electropack/shockcollar,
-/obj/item/electropack/shockcollar/explosive,
-/obj/item/electropack/shockcollar/explosive,
-/obj/item/electropack/shockcollar/explosive,
-/obj/structure/closet/crate,
-/obj/item/assembly/signaler,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 4
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/item/cigbutt{
+	anchored = 1;
+	color = "#808080";
+	pixel_x = 17;
+	pixel_y = 1
+	},
+/turf/open/floor/bronze{
+	name = "floor"
 	},
 /area/f13/brotherhood)
 "yhM" = (
@@ -21601,10 +24616,35 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"yix" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/brotherhood)
 "yiE" = (
-/obj/effect/spawner/structure/window/plastitanium,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
+	dir = 1;
+	name = "prewar lounge chair"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
 /area/f13/brotherhood)
 "yjt" = (
 /obj/structure/rack,
@@ -21622,8 +24662,19 @@
 	},
 /area/f13/followers)
 "yke" = (
-/obj/structure/stairs/east,
-/turf/open/floor/plasteel/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood)
 "ykl" = (
 /obj/structure/chair/booth{
@@ -21632,9 +24683,11 @@
 /turf/open/floor/wood/wood_common,
 /area/f13/tunnel/bighorn)
 "ykM" = (
-/obj/machinery/flasher/portable,
-/obj/effect/turf_decal/box,
-/obj/item/wrench,
+/obj/structure/chair/bench{
+	dir = 4;
+	pixel_y = 1;
+	pixel_x = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "yle" = (
@@ -69904,39 +72957,13 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
 oVq
 oVq
 oVq
@@ -69944,12 +72971,38 @@ oVq
 oVq
 oVq
 oVq
-aae
-aae
-aae
-aae
-aae
-aae
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
 aae
 aae
 aae
@@ -70161,39 +73214,39 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
 oVq
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
 oVq
+icO
+fFB
+fFB
+fFB
+yer
 oVq
-aae
-aae
-aae
-aae
-aae
-aae
-oVq
-oVq
-oVq
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+plP
+gFV
+mDf
+sWg
+qpx
+lPd
 oVq
 esP
 esP
@@ -70205,8 +73258,8 @@ oVq
 oVq
 oVq
 oVq
-aae
-aae
+ryF
+ryF
 aae
 aae
 aae
@@ -70401,6 +73454,7 @@ aaa
 aae
 aae
 aae
+aak
 aae
 aae
 aae
@@ -70417,64 +73471,63 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-oVq
-oVq
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
 oVq
 iqA
-oVq
-oVq
-oVq
-oVq
-oVq
-oVq
-oVq
-oVq
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
 iqA
 oVq
+cTh
+onW
+onW
+onW
+tWa
 oVq
-oVq
-oVq
-oVq
-oVq
-oVq
-oVq
-oVq
-oVq
-oVq
-oVq
-oVq
-oVq
-oVq
-oVq
+mGk
+nVS
+nPk
+sWg
+qpx
+qpx
 oVq
 rVv
-onW
-onW
+ajc
+ajc
 onW
 wrP
 oVq
 giI
 kRc
 bXq
-oVq
-aae
-aae
-aae
-aae
-aae
-aae
-aak
+vef
+ryF
+ryF
 aae
 aae
 aae
 aae
 aak
-aaa
+aae
+aae
+dNs
+dNs
+dNs
+dNs
 aae
 aae
 aaa
@@ -70658,7 +73711,7 @@ aaa
 aaa
 aae
 aae
-aae
+aak
 aae
 aae
 aae
@@ -70675,64 +73728,64 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
+ryF
+ryF
+ryF
+ryF
+lBb
+ryF
+ryF
 oVq
-uQM
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
 oVq
+sXj
 ajc
-qiz
 ajc
 ajc
-onW
-onW
+tWa
 oVq
-gFV
-wZq
-oVq
+ufL
+nVS
 jak
-dWc
-dWc
+sWg
+qpx
 qpx
 oVq
 xMZ
-onW
-onW
+aBm
+ajc
 onW
 mtl
 niq
 xMZ
-onW
-wrP
-oVq
-aak
-aak
+ajc
+soX
+vef
+lBb
+lBb
 aak
 aak
 aak
 aae
 aae
+dNs
 aae
-aae
-aae
-aak
-aak
-aae
-aae
+dNs
+gPb
+gPb
+dNs
+dNs
 aae
 aaa
 "}
@@ -70915,7 +73968,7 @@ aaa
 aaa
 aae
 aae
-aae
+aak
 aae
 aak
 aae
@@ -70932,65 +73985,65 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
+ryF
+ryF
+ryF
+lBb
+lBb
+ryF
+ryF
 oVq
-uQM
-gwL
-gwL
-gwL
-gwL
-gwL
-gwL
-gwL
-gwL
-gwL
-gwL
-gwL
-gwL
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
 oVq
-onW
-xMo
 saZ
-ssA
-knT
-onW
-wwI
-skf
-sDR
+ajc
+ajc
+ajc
+nDp
+oVq
+xOR
 nVS
-xMZ
-onW
-onW
-mKl
+jak
+sWg
+sWg
+fLs
 oVq
 oWD
-onW
-ajc
+aBm
+aBm
 ajc
 mtl
 dHy
 ggn
 ajc
-sDR
+mtl
+vef
 oVq
-aae
-aae
-aae
-aae
-aak
-aae
-aae
-aae
-aae
-aae
-aak
-aae
-aae
-aae
-aae
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+geO
+geO
+geO
+sSo
+sSo
+sSo
+geO
+geO
 aaa
 "}
 (193,1,1) = {"
@@ -71172,7 +74225,7 @@ aaa
 aaa
 aae
 aae
-aae
+aak
 aae
 aak
 aae
@@ -71189,39 +74242,39 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
+ryF
+lBb
+lBb
+lBb
+lBb
+ryF
+ryF
 oVq
-uQM
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
 oVq
-onW
-jWs
-saZ
-saZ
-oUx
+tWa
+ajc
+ajc
 ajc
 wwI
-jkr
-eof
 oVq
-rEc
-onW
-onW
-bRg
+eof
+nVS
+lQa
+jRx
+jRx
+vOB
 oVq
 oWD
 onW
@@ -71233,21 +74286,21 @@ xMZ
 onW
 mtl
 oVq
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+icO
+fFB
+fFB
+fFB
+hVT
+ful
+oVq
+geO
+sSo
+sSo
+sSo
+sSo
+sSo
+sSo
+geO
 aaa
 "}
 (194,1,1) = {"
@@ -71429,6 +74482,7 @@ aaa
 aae
 aae
 aae
+aak
 aae
 aae
 aae
@@ -71443,42 +74497,41 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aak
+aak
+lBb
+ryF
+ryF
+lBb
+ryF
+ryF
+ryF
 oVq
-uQM
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
 oVq
-onW
-qFr
+bhS
 ajc
 ajc
 ajc
-ajc
+xUW
 oVq
-krv
 bvu
-oVq
-mpk
-onW
-onW
-bRg
+gFV
+eif
+vCA
+sWg
+jak
 oVq
 lsS
 onW
@@ -71490,21 +74543,21 @@ tRK
 unO
 lhc
 oKn
-aAX
-rGz
-gtG
-irV
+onW
+onW
+onW
+oVq
 rMI
-uyb
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+rMI
+oVq
+oVq
+rMI
+rMI
+nEP
+oVq
+eKy
+eKy
+oVq
 aaa
 "}
 (195,1,1) = {"
@@ -71686,7 +74739,7 @@ aaa
 aae
 aae
 aae
-aae
+aak
 aae
 aae
 aae
@@ -71700,42 +74753,42 @@ aae
 aae
 aae
 aak
+aak
+aak
 aae
-aae
-aae
-aae
-aae
-aae
-aae
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
 oVq
-uQM
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
+iqA
 oVq
-oVq
-oVq
-oVq
-oVq
-rri
-oVq
-oVq
-oVq
-oVq
-oVq
-mpk
+wwI
+ajc
+ajc
+ajc
 onW
-onW
-onW
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+ubO
 oVq
 oVq
 vRZ
@@ -71747,21 +74800,21 @@ oVq
 vRZ
 oVq
 oVq
-uyb
-rGz
-mme
+pHE
+onW
+onW
 kUs
 bYo
-uyb
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+rUK
+iGl
+wwj
+bYo
+rUK
+bhZ
+xab
+rUK
+rUK
+oVq
 aaa
 "}
 (196,1,1) = {"
@@ -71943,10 +74996,10 @@ aaa
 aaa
 aae
 aae
+aak
 aae
 aae
-aae
-aae
+aak
 aae
 aak
 aak
@@ -71960,65 +75013,65 @@ aak
 aak
 aae
 aae
-aae
-aae
-aae
-aae
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
 oVq
-uQM
+pAW
+wNJ
+iLK
+umJ
 gwL
+gXg
 gwL
-gwL
-gwL
-gwL
-gwL
-gwL
-gwL
-gwL
-gwL
-gwL
-gwL
+ebG
+bCy
+hUK
+qyY
 oVq
-mMU
-nDp
-ljv
-siG
-mIf
-vGf
+oVq
+onW
+ajc
+ajc
+ajc
+onW
 icO
-icO
-cdO
-mQC
 fFB
-onW
-onW
-onW
-onW
-onW
+fFB
+fFB
+jAK
+yer
+waD
+oVq
+bhF
 ajc
-fta
+hHh
 ajc
-fta
-tau
-dWc
-fta
-fta
-pXS
-uyb
-gXT
-unv
-ktb
+oUx
+fFB
+yer
+ajc
+oUx
+yer
+onW
+onW
+onW
+oVq
 frP
-uyb
-uyb
-uyb
-uyb
-aae
-aae
-aae
-aae
-aae
-aae
+ovP
+iGl
+xab
+mpp
+ldj
+iGl
+iGl
+tGp
+sXE
+oVq
 aaa
 "}
 (197,1,1) = {"
@@ -72200,10 +75253,10 @@ aaa
 aaa
 aae
 aae
+aak
 aae
 aae
-aae
-aae
+aak
 aae
 aak
 aak
@@ -72217,65 +75270,65 @@ aak
 aae
 aae
 aae
-aae
-aae
-aae
-aae
+ryF
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
 oVq
-uQM
-pAo
-pAo
-pAo
-pAo
-pAo
+sQF
+aAb
+aAb
 pAo
 krl
+jWs
+krl
 pAo
+aAb
 pAo
-pAo
-pAo
-pAo
+xPK
 oVq
-eWJ
-sxz
-dvB
-sIH
-bNZ
-smj
+wwI
+onW
+onW
+onW
 ajc
-hLB
-yas
-fKd
-dZP
-piz
+onW
+ajc
+ajc
+aBm
+aBm
+ajc
+ajc
 wce
-wce
-dbO
-gFh
-gFh
-gFh
-gFh
-gFh
-mWI
-gFh
-wce
-tTa
-bRg
-uyb
-qpr
-rGz
-rGz
-rGz
+oVq
+bhF
+onW
+hxl
+bNZ
+bNZ
+bNZ
+bNZ
+wSs
+wSs
+bNZ
+wSs
+wSs
+jfH
+kUs
+kUa
 kKh
-lgh
 iGl
-uyb
-aae
-aae
-aae
-aae
-aae
-aae
+iGl
+mpp
+mpp
+iGl
+xab
+mst
+mpp
+oVq
 aaa
 "}
 (198,1,1) = {"
@@ -72457,18 +75510,9 @@ aaa
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
 aak
 aae
 aae
-aae
-aae
-aae
-aak
 aak
 aae
 aak
@@ -72477,62 +75521,71 @@ aae
 aae
 aae
 aae
+aak
+aak
+aae
+aak
+aae
+aae
+ryF
+lBb
+lBb
+ryF
+ryF
+ryF
+ryF
 oVq
-oVq
-oVq
-boy
 pYk
-pYk
-jZb
-weG
+qNe
+qZg
 pvA
 weG
-rzF
+qNe
 blY
-blY
-tsK
-lQa
+weG
+qZg
+qNe
+svq
 oVq
-oIm
-oIm
-oVq
-oWD
+onW
+onW
+ykM
 ykM
 fhn
-yhd
-lCI
-gxc
-vxi
-dZP
-mKl
-wJa
-oPY
-oPY
-oPY
-oPY
-oPY
-oPY
-oPY
-oPY
-oPY
-wJa
-vaL
-oKn
-uGa
-gXT
-gXT
-rGz
+onW
+ajc
+aBm
+aBm
+ajc
+aBm
+aBm
+hgY
+vef
+pWb
+ajc
+hgY
+jov
+tau
+aBm
+jov
+ajc
+ajc
+ajc
+ajc
+ajc
+waD
+kUs
 dSb
-uyb
-jxG
-pbB
-uyb
-aae
-aae
-aae
-aae
-aak
-aae
+hMQ
+wHD
+iGl
+dSb
+lIj
+dee
+iGl
+hMQ
+hMQ
+oVq
 aaa
 "}
 (199,1,1) = {"
@@ -72718,78 +75771,78 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aak
 aae
 aae
 aae
 aae
 aae
+aak
+aak
 aae
+aak
+aae
+aae
+aae
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
 oVq
-oVq
-oVq
-cAT
-tjj
-nnk
-nnk
+equ
+qNe
+qNe
+blY
 nfe
-nfe
-nfe
+qZg
 nnk
-nnk
-nnk
-dlD
-mLD
+weG
+qNe
+qZg
 qmH
-lqS
-gra
+oVq
+onW
 qQK
-oWD
-ajc
+rWu
+aEY
 vuj
-oVq
-oIm
-oIm
-oVq
-dZP
-sDR
-pna
+hbN
+wSs
+wSs
+wSs
+wSs
+wSs
+wSs
 jbz
-bkj
-cTr
-vXx
+ije
+wSs
+wSs
 iGb
-aGN
-vwE
+onW
 bkj
-eii
-dzS
-oWD
+bkj
+bkj
+onW
+mFx
 mKl
-uyb
-tgR
-xwF
-gXT
-gXT
-uyb
-qfa
+onW
+ajc
+waD
+oVq
+ues
+fkv
+axq
 wHD
-uyb
-aae
-aae
-aae
-aae
-aae
-aae
+iGl
+wHD
+dee
+wHD
+xab
+xab
+oVq
 aaa
 "}
 (200,1,1) = {"
@@ -72976,10 +76029,7 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
+aak
 aae
 aae
 aae
@@ -72987,66 +76037,69 @@ aae
 aak
 aae
 aae
+aak
 aae
 aae
 aae
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
 oVq
-oVq
-eUW
-oVq
-dee
-onW
-onW
-xiQ
-xiQ
-onW
+pmx
+qNe
 qZg
-wFn
-onW
-onW
-onW
-mNH
+acU
+qZg
+qZg
+qZg
+qZg
+qZg
+qNe
+aQB
 oVq
-oIL
-dYS
+onW
 ljv
-bot
-bNZ
+sSo
+nKw
 kdZ
-pXb
+waD
 mPJ
-lqS
 oVq
-iFV
-aTN
-hFx
-kSu
-nxn
+vef
+wBj
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
 ubO
-ubO
-ubO
-nxn
-nxn
-nxn
-xeo
-oPY
-kHa
-fZM
-bEX
-rdL
-jov
-tsu
-rGz
-uyb
-uyb
-uyb
-uyb
-aae
-aae
-aae
-aae
-aae
-aae
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+pHE
+ajc
+waD
+oVq
+yaj
+iGl
+cAN
+wHD
+xab
+iGl
+cdI
+cdI
+hUw
+oVq
+oVq
 aaa
 "}
 (201,1,1) = {"
@@ -73234,76 +76287,76 @@ aak
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-oVq
-ovP
-onW
-omy
-ibq
-onW
-onW
-omy
-qNe
-onW
-omy
-jqz
-onW
-onW
-onW
-nfk
-oVq
-oVq
-oVq
-oVq
-sSo
-tOy
-xkz
-yiE
-ebG
-eLA
-oVq
-oEg
-imi
-ovV
-iIa
-nxn
-sLV
-lPe
-lPe
-nxn
-nxn
-nxn
-xeo
-dzS
-oWD
-bRg
-uyb
-aAv
-wUV
-eRL
-gXT
-uyb
-aae
-aae
-aae
-aae
+aak
+aak
 aae
 aak
 aae
 aae
 aae
+aae
+aae
+aae
+aae
+lBb
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
+eQw
+qZg
+qNe
+qZg
+omy
+nfk
+xMh
+nfk
+xMh
+nfk
+eBa
+oVq
+onW
+gYC
+sSo
+tOy
+xkz
+hgY
+tWa
+oVq
+oEg
+oEg
+imi
+oEg
+pwh
+rCb
+sLV
+lPe
+hoa
+oVq
+pPC
+psO
+thB
+dzS
+pPC
+oVq
+wwI
+ajc
+wUV
+eRL
+fkv
+eii
+dYS
+iGl
+xab
+oVq
+xTo
+xTo
+xTo
+oVq
+oVq
 aaa
 "}
 (202,1,1) = {"
@@ -73493,6 +76546,8 @@ aae
 aae
 aae
 aae
+aak
+aak
 aae
 aae
 aae
@@ -73500,67 +76555,65 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
 oVq
-plP
-onW
-omy
-ibq
-onW
-onW
+oVq
 oNP
-onW
-onW
-onW
-onW
-unO
-onW
-onW
-nfk
+flq
+kZu
+egw
+qNe
+qZg
+qNe
+msi
+qNe
+vqM
 oVq
-aae
-aae
+onW
+onW
+rCd
+fVC
+vBu
+hgY
+tWa
 oVq
-uyb
-uyb
-uyb
-bEX
-uyb
-uyb
-uyb
-dZP
-mKl
+qyx
+qyx
+oEg
 wJa
-cdV
+pwh
 wNE
 mco
-mco
-mco
-kWr
+rmQ
+mNH
+oVq
 mib
-jfH
+fNu
 xeo
-wJa
-mpk
-bRg
-uyb
-lii
-pif
-mEL
-gXT
-uyb
-aae
-aae
-aak
-aak
-aak
-aak
-aak
-aae
-aae
+lpA
+seX
+oVq
+tWa
+onW
+waD
+oVq
+cbR
+hMq
+wHD
+iGl
+xab
+nOc
+nAc
+nAc
+nAc
+kWr
+oVq
 aaa
 "}
 (203,1,1) = {"
@@ -73759,65 +76812,65 @@ aae
 aae
 aae
 aae
-aae
-aae
-qPZ
-onW
-onW
-onW
-onW
-onW
-leW
-uyb
-uyb
-uyb
-uyb
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
+oVq
+oVq
+vYD
+oVq
+oVq
+xEX
 bEX
-aEf
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
+bEX
+bEX
+oVq
+oVq
+oVq
+oVq
+onW
+onW
 edQ
-mfA
+edQ
+edQ
 hgY
-rGz
-rGz
-iiN
-hxl
-mKl
-oPY
-dky
-hFx
-cOG
-vcF
-aIP
-oPY
-oPY
+wwI
+oVq
+oEg
+oEg
+wJa
+qyx
+pwh
+wNE
+mco
+dEl
+gYI
+oVq
+wtQ
 lpA
-stF
-oPY
-mpk
-mKl
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-aak
-aak
-aak
-aak
-aae
-aae
+thB
+udp
+kzw
+oVq
+tWa
+onW
+hgY
+oVq
+oVq
+bXU
+vef
+ppn
+ppn
+oVq
+tMX
+iIa
+nAc
+teH
+oVq
 aaa
 "}
 (204,1,1) = {"
@@ -74015,66 +77068,66 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-eKy
-prD
-onW
-onW
-onW
-onW
-onW
-uyb
+aak
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+enq
+gra
+pOB
+oYO
 oYO
 cTY
 kKT
-uyb
-rGz
-bEk
-jxG
-xPK
-uyb
+tEu
+ajc
+ajc
+onW
+onW
+ajc
 hHh
-avL
-qcd
-pPC
-jxG
-fhh
-sUJ
-oiJ
-rGz
-uyb
-dZP
-mKl
-oPY
-ftF
-jfH
-jVE
-mpp
-vwE
-hQG
-axe
+onW
+onW
+onW
+onW
+ajc
+waD
+xUW
+oVq
+oEg
+wJa
+oEg
+qyx
+pwh
+wNE
+mco
+dEl
+pwh
+oVq
+gtG
+gTT
 thB
-thB
-oPY
-mpk
-mKl
-uyb
-qpr
-gXT
-gXT
-gXT
+cdO
+gTT
+oVq
+wwI
+onW
+hgY
+oVq
+frx
 fZh
 tMu
-iGl
-uyb
-aae
-aae
-aak
-aak
-aae
-aae
+lBs
+nWO
+lfq
+lCI
+lCI
+lCI
+sHl
+oVq
 aaa
 "}
 (205,1,1) = {"
@@ -74263,6 +77316,7 @@ aae
 aae
 aak
 aak
+aak
 aae
 aae
 aae
@@ -74270,68 +77324,67 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-hyi
-lnh
-onW
-onW
-onW
-onW
-onW
-uyb
+aak
+aak
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
+sJU
+xoI
+gra
 jrv
-qGY
-jxG
+oVq
+hFj
 taI
-rGz
-jxG
-qDV
-gGI
-uyb
+bNZ
+wSs
+wSs
+wSs
+bNZ
 voJ
-bTe
-pEf
-uyb
-tex
+bNZ
+wSs
+gAA
+lTk
 jxG
-jxG
-rGz
-rGz
-uyb
-iFV
-aTN
-oPY
-gog
-dxA
-iBP
+gkY
+onW
+oVq
+aBz
+oEg
+oEg
+oEg
+gYI
+iuf
+gYI
 dEl
 aJF
-lPd
-axe
-qyx
-vKT
-oPY
+oVq
 mpk
-oKn
-tbI
-rGz
-rGz
-gXT
+mpk
+kwH
+mpk
+mpk
+oVq
+tWa
+onW
+hgY
+oVq
 cZy
-uyb
-jxG
-pbB
-uyb
-aae
-aae
-aae
-aae
-aae
-aae
+gOa
+lqS
+dNu
+wFn
+lfq
+nAc
+lCI
+lCI
+maB
+oVq
 aaa
 "}
 (206,1,1) = {"
@@ -74528,67 +77581,67 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-iEP
-bSF
-xwg
+aak
+aak
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
+ssA
+xoI
+gra
+gra
+oVq
+tHm
 onW
-onW
-onW
-onW
-uyb
-uyb
-uyb
-uyb
-uyb
-gXT
-nOc
+ajc
 jov
-xxs
-uyb
-vWC
-uyb
-uyb
-uyb
-dSb
-rGz
-rGz
-rGz
-rGz
-uyb
-dZP
-mKl
-oPY
-vca
-xVA
+jov
+aBm
+ajc
+aBm
+ajc
+onW
+waD
+aBm
+aBm
+ajc
+onW
+vRZ
+oEg
+oEg
+hDv
+oEg
+gYI
+oEg
 srm
 pKe
-mco
-gQu
-axe
+sQq
+oVq
+fSP
+oEg
 qyx
-thB
-oPY
-mpk
-mKl
-uyb
-tgR
-cZL
-rGz
-gXT
-uyb
-qfa
+oEg
+odU
+oVq
+tWa
+onW
+hgY
+oVq
+kRQ
+hTw
+hQG
 jdz
-uyb
-aae
-aae
-aae
-aae
-aae
-aae
+dNu
+lfq
+lCI
+lCI
+nAc
+fCf
+vef
 aaa
 "}
 (207,1,1) = {"
@@ -74784,68 +77837,68 @@ aak
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
+aak
+aak
+aak
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
 oVq
+omE
+aZE
+pna
+gra
 oVq
-oVq
-vZh
+nrx
 onW
-onW
-onW
-uyb
-xrn
-otJ
-otJ
-qMG
-gXT
-rGz
+aBm
+tau
 lvS
-gXT
-uyb
+qzt
+bkj
 vef
-otJ
-otJ
+oVq
+vef
 qof
-rGz
-rGz
-vfZ
-fVC
-jxG
-uyb
-dZP
-mKl
-oPY
+vef
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
 uPJ
-dxA
-hAz
-hqe
-dxA
-qmp
+khl
+oVq
+rGa
+oVq
+oVq
 axe
 qyx
-qyx
-oPY
+myg
+oEg
 rEc
-fZM
-bEX
-rdL
-sUJ
-wLq
-gXT
-uyb
-uyb
-uyb
-uyb
-aae
-aae
-aak
-aae
-aae
-aae
+oVq
+xUW
+ajc
+rLF
+oVq
+lcx
+qGz
+iZr
+jdz
+dNu
+lfq
+oCe
+jiV
+iIa
+kTN
+nEP
 aaa
 "}
 (208,1,1) = {"
@@ -75042,67 +78095,67 @@ aae
 aae
 aae
 aak
+aak
 aae
-aae
-aJq
-aJq
-aJq
-aJq
+ryF
+lBb
+lBb
+ryF
+ryF
+ryF
 oVq
-jwv
-oNP
-onW
-onW
-uyb
-xab
-nua
+oVq
+oVq
+oVq
+oVq
+vef
 nrx
-uyb
-cZy
-yaj
-rGz
+ajc
+aBm
+ajc
+tWa
 tgR
-uyb
-pOB
+oVq
+oVq
 ueK
 rmR
-uyb
+mAW
 bYF
 szm
 laA
 aqQ
 fjV
-uyb
+wQJ
 dZP
-mKl
-oPY
+gsU
+xui
 pJG
-xVA
-nKw
+uBR
+uBR
 xjH
 xVA
-hMQ
-oPY
+oVq
+gXR
 sLQ
 vKT
-oPY
-vaL
-bRg
-uyb
-mEL
-wUV
-eRL
-gXT
-uyb
-aae
-aae
-aae
-aae
-aae
-aak
-aae
-aae
-aae
+mpk
+mpk
+oVq
+onW
+ajc
+hgY
+oVq
+oiJ
+doL
+imX
+ogR
+rhX
+lfq
+oMu
+oMu
+lCI
+vZh
+oVq
 aaa
 "}
 (209,1,1) = {"
@@ -75284,7 +78337,7 @@ aae
 aae
 aae
 aae
-aae
+aak
 aae
 aae
 aae
@@ -75299,67 +78352,67 @@ aak
 aae
 aae
 aae
+aak
 aae
-aae
-aJq
-ciN
-ciN
-aJq
-oVq
-oVq
-oVq
+lBb
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
 nZR
-nZR
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
+ivn
+lld
+oVq
+mVc
+aBm
+jov
+aBm
 aEf
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-dZP
-mKl
-oPY
+qUn
+oVq
+rga
+jwv
+mNH
+gYI
+oVq
+hxS
+lmq
+lmq
+lmq
+lmq
+lmq
+yke
+qGX
 xum
-jfH
+rfX
 gGe
 hqe
 dxA
-nxn
+oVq
 laf
-thB
-sLQ
-oPY
+rws
+aNu
+uYW
 vaL
-bRg
-uyb
+oVq
+wwI
 aBm
-pif
-mEL
-gXT
-uyb
-aae
-aae
-aak
-aae
-aae
-aak
-aae
-aae
-aae
+hgY
+oVq
+sSG
+iom
+nho
+iCl
+fKd
+sZn
+oIm
+iko
+lCI
+aAk
+oVq
 aaa
 "}
 (210,1,1) = {"
@@ -75541,12 +78594,12 @@ aae
 aae
 aae
 aae
+aak
 aae
 aae
 aae
 aae
-aae
-aae
+aak
 aae
 aae
 aak
@@ -75556,67 +78609,67 @@ aak
 aak
 aak
 aae
+aak
 aae
-aae
-aJq
-ecF
-ciN
-aJq
+lBb
+ryF
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
 oVq
-aVt
+wZq
+tGl
+oxw
+jov
+aBm
 tau
-ehp
-ehp
-tau
-fta
-fta
-fta
-fta
-tau
+aBm
+ajc
+qUn
+oVq
+rGt
+gYI
+gYI
+pwh
+oVq
+jGM
+ovV
+ovV
 dWc
-mIf
-dWc
-dWc
-dWc
-tau
-fta
-fta
-fta
-fta
-tau
-fta
-dWc
-dWc
+ogj
 qfo
-mKl
-oPY
+pKe
+jPL
 vmp
-jfH
+vmp
 uBR
 cYq
 wUI
-oPY
+oVq
 hFx
-oPY
-oPY
-oPY
-mpk
-bRg
-tWa
-tWa
-tWa
-tWa
-tWa
-tWa
-tWa
-tWa
-tWa
-aae
-aae
-aak
-aae
-aae
-aae
+oEg
+yfV
+lyJ
+rCs
+aYb
+wSs
+jxG
+qoh
+oVq
+oVq
+oVq
+oVq
+gUG
+gBw
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
 aaa
 "}
 (211,1,1) = {"
@@ -75802,7 +78855,7 @@ aae
 aae
 aae
 aae
-aae
+aak
 aae
 aae
 aae
@@ -75813,67 +78866,67 @@ aak
 aae
 aae
 aae
+aak
 aae
-aae
-aJq
-ciN
-ciN
-aJq
+lBb
+ryF
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
 oVq
-baR
-ief
-onW
-onW
-onW
-gFh
-gFh
-gFh
-gFh
-gYI
-ivn
-gFh
-wce
-wce
-wce
+oVq
+oVq
+oVq
+hFj
+aBm
+tau
+aBm
+ryt
+qUn
+oVq
+hvw
 gYI
 gFh
-gFh
-gFh
-gFh
 gYI
-wce
-gFh
-gFh
-rLF
-mKl
-oPY
-oDv
-jfH
+oVq
+vGf
+pwh
+szF
+pwh
+gYI
+gYI
+dEl
+xBH
+uBR
+uBR
 nxn
-nxn
-nxn
-tsV
+jGM
+kRz
+oVq
 vwE
-vwE
-gxz
-oPY
-vaL
-bRg
-tWa
-kzw
-gei
-gJE
-avf
+oVq
+oVq
+oVq
+vRZ
+oVq
+oVq
+ajc
+hgY
+onW
+xUW
 qiR
 sAM
-qiR
-tWa
-aae
-aae
-aae
-aae
-aae
-aae
+ffG
+bwr
+hsV
+owd
+owd
+hsV
+wVL
+oVq
 aaa
 "}
 (212,1,1) = {"
@@ -76070,67 +79123,67 @@ aae
 aae
 aae
 aae
-aae
-aae
-aJq
-eYn
-vRZ
-eYn
-oVq
-biK
-ivn
-ivn
-ivn
-ivn
-oVq
-wBd
-wBd
-oVq
-oVq
-nZR
-oVq
-oVq
-wBd
-wBd
-oVq
-oVq
-tsi
-tsi
-tsi
-tsi
-tsi
-tsi
-tsi
-dZP
-mKl
-oPY
-qnu
-nxn
-xDG
-nxn
-aoY
-mDf
-nxn
-jfH
-sEa
-oPY
-vaL
-bRg
-tWa
-vFe
-pHE
-gJE
-tWa
-cYU
-gdZ
-gdZ
-tWa
-aae
-aae
 aak
-aae
-aae
-aae
+aak
+lBb
+ryF
+ryF
+ryF
+lBb
+ryF
+ryF
+ryF
+soR
+ivn
+rri
+oVq
+wBd
+aBm
+jov
+ajc
+ajc
+qUn
+oVq
+kaf
+gYI
+beW
+gYI
+oVq
+jGM
+ovV
+iHL
+xxs
+dWc
+dWc
+pKe
+ojX
+qnu
+nvm
+vef
+dfq
+jkI
+oVq
+twY
+jfH
+eFw
+cEz
+ajc
+ajc
+oVq
+vFe
+hgY
+onW
+onW
+qiR
+gdZ
+ffG
+mMU
+ffG
+qyr
+ffG
+xdR
+eOS
+oVq
 aaa
 "}
 (213,1,1) = {"
@@ -76311,6 +79364,11 @@ aae
 aae
 aae
 aae
+aak
+aae
+aae
+aae
+aak
 aae
 aae
 aae
@@ -76322,72 +79380,67 @@ aae
 aae
 aae
 aae
+aak
 aae
-aae
-aae
-aae
-aae
-aae
-aae
+lBb
+ryF
+ryF
+ryF
+lBb
+ryF
+ryF
+ryF
 oVq
-jOo
-onW
-onW
-oVq
-oVq
-ixJ
-mIf
-mIf
 wZq
-oVq
+qyT
 ixJ
-mIf
-mIf
-mIf
-mIf
-mIf
-mIf
-mIf
-ikR
+aBm
+aBm
+jov
+ajc
+aEf
+qUn
 oVq
-aae
-tsi
-pWb
+ikR
+gYI
+pwh
+gYI
+oVq
 jGM
 pwh
-jGM
-xWy
-tsi
-iFV
-aTN
-oPY
-kUa
-nxn
-eOS
-nxn
+pwh
+pwh
+szF
+szF
+pKe
+szF
+gYI
+avL
+vef
+pwh
 aoY
-cdI
-nxn
-nxn
+oVq
+dqX
+rLF
 eFw
-oPY
+pvC
 kHa
 fZM
+oVq
+hFj
+hgY
+ajc
 tWa
-beo
-xUW
-gJE
-tWa
-tWa
-tWa
-tWa
-tWa
-aae
-aae
-aae
-aae
-aae
-aae
+qiR
+gip
+ffG
+bwr
+bpy
+idX
+idX
+ffG
+iEP
+oVq
 aaa
 "}
 (214,1,1) = {"
@@ -76568,11 +79621,11 @@ aae
 aak
 aae
 aae
-aae
 aak
 aak
 aak
-aae
+aak
+aak
 aae
 aae
 aae
@@ -76584,67 +79637,67 @@ aae
 aae
 aae
 aae
-aae
-aae
+aak
+aak
+lBb
+lBb
+ryF
+ryF
+lBb
+ryF
+ryF
+ryF
 oVq
-lfq
-onW
-onW
-onW
-nZR
-oWD
-onW
+oVq
+oVq
+oVq
+hFj
+aBm
+jov
 ajc
-mtl
-wBd
-oWD
-dNu
-dNu
-onW
-sZn
-onW
-dNu
-dNu
-sDR
+ief
+tgR
 oVq
-aae
-tsi
-iOT
-hci
-hci
-jGM
-epj
-tsi
-dZP
-mKl
-oPY
+oVq
+hQj
+gYI
+gYI
+oVq
+iBP
+pwh
+dWc
+dXl
+qbZ
+wqS
+dEl
+gYI
 ghI
-nxn
-nxn
-jfH
+qDV
+oVq
+yfr
 uab
-wVL
-jfH
-nxn
+oVq
+xMG
+pSP
 aYb
-oPY
-vaL
-bRg
-tWa
+bNZ
+bNZ
+leW
+oVq
 kaX
-gJE
-gJE
-nEP
-gdZ
-gdZ
-gdZ
-tWa
-aae
-aae
-aae
-aae
-aae
-aae
+twY
+oEl
+wSs
+eRL
+oFB
+oFB
+jYk
+bpy
+ibq
+bpy
+xdR
+owd
+oVq
 aaa
 "}
 (215,1,1) = {"
@@ -76825,16 +79878,9 @@ aae
 aae
 aae
 aae
-aae
 aak
 aak
 aak
-aae
-aae
-aae
-aae
-aae
-aae
 aak
 aae
 aae
@@ -76842,66 +79888,73 @@ aae
 aae
 aae
 aae
+aak
 aae
-oVq
+aae
+aae
+aae
+aae
+aae
+aak
 lBb
-ajc
-ajc
-onW
-nZR
-oWD
-onW
-ajc
-mtl
-wBd
-oWD
-dNu
-dNu
-onW
-sZn
-onW
-dNu
-dNu
-sDR
+lBb
+lBb
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
 oVq
-aae
-tsi
-pWb
-hci
-hci
-jGM
-xWy
-tsi
-dZP
-mKl
-oPY
-xEX
-nPD
-aDq
-mco
-aTI
-bCy
-mco
-mco
-gip
-oPY
-mpk
-mtl
-aUl
-gJE
-gJE
-gJE
+oVq
+wBd
+onW
+aBm
+onW
 tWa
-fSP
+sNC
+fFB
+oVq
+oVq
+oVq
+ftF
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+ubO
+vRZ
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+boy
+oVq
+oVq
+vRZ
+oVq
+oVq
+oVq
+gJE
+hgY
+ddo
+oVq
 bsE
-qiR
-tWa
-aae
-aae
-aae
-aae
-aae
-aae
+ffG
+oJz
+bpy
+wlK
+bpy
+bpy
+owd
+oVq
 aaa
 "}
 (216,1,1) = {"
@@ -77082,10 +80135,10 @@ aae
 aae
 aae
 aae
+aak
 aae
 aae
-aae
-aae
+aak
 aae
 aae
 aae
@@ -77098,67 +80151,67 @@ aae
 aae
 aae
 aae
-aae
-aae
+aak
+aak
+lBb
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
 oVq
-jOo
+uQM
+onW
+ajc
+tau
 ajc
 ajc
 ajc
+ajc
+ajc
+onW
+ajc
+onW
+sDR
+vRZ
+oWD
+onW
+onW
+onW
+onW
+waD
+onW
 oVq
-tRK
-bkS
-ivn
-lhc
+lnh
+mLD
+qDT
+oPY
+ciN
+ajc
+hgY
+pLs
+hNm
+iFV
+nHJ
+aJq
 oVq
-oCe
-unO
-gXR
-unO
-unO
-unO
-gXR
-unO
-oFB
-tsi
-tsi
-tsi
-tsi
-tsi
-wTx
-tsi
-tsi
-tsi
-dZP
-mKl
-oPY
-oPY
-oPY
-oPY
-oPY
-oPY
-oPY
-bwr
-hMq
-oPY
-oPY
-mpk
-bRg
 tWa
-tWa
-tWa
-tWa
-tWa
-tWa
-tWa
-tWa
-tWa
-aae
-aae
-aae
-aae
-aae
-aae
+waD
+ajc
+lmM
+gip
+ffG
+psR
+idX
+duV
+wlK
+xdR
+iEP
+oVq
 aaa
 "}
 (217,1,1) = {"
@@ -77329,20 +80382,20 @@ aae
 aae
 aae
 aae
+aak
+aae
+aae
+aak
+aae
+aak
+aae
+aak
 aae
 aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aak
 aae
 aae
 aae
@@ -77355,67 +80408,67 @@ aae
 aae
 aae
 aae
-aae
-aae
+aak
+aak
+ryF
+ryF
+lBb
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
 oVq
-oVq
-vRZ
-vRZ
-oVq
-oVq
-oVq
-oVq
-oVq
-oVq
-oVq
-oVq
-oVq
-oVq
-tsi
-tsi
-tsi
-tsi
-tsi
-tsi
-tsi
-reU
-jGM
+uQM
+onW
+onW
+onW
+ajc
+ajc
+ajc
+ajc
+ajc
+ajc
+ajc
+onW
 lEP
-jGM
-jGM
-doL
-jKl
-tsi
-dZP
-mKl
-iPf
-pSP
-ibY
-eBa
-idX
+vRZ
+oWD
+onW
+onW
+onW
+onW
+hxl
+wSs
+syK
+bNZ
+bNZ
+bNZ
 lIt
 lTk
-fVI
-fVI
+bNZ
+mfI
 edO
 iPf
 cyI
 rOj
-aQB
+cyI
 syK
-syK
+wSs
 lmN
-ceF
+ajc
+gUG
+gdZ
 ffG
-msk
-qiR
-tWa
-aae
-aae
-aak
-aae
-aae
-aae
+oJz
+idX
+wlK
+idX
+bpy
+eOS
+oVq
 aaa
 "}
 (218,1,1) = {"
@@ -77594,21 +80647,8 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aak
+aak
 aak
 aae
 aae
@@ -77625,54 +80665,67 @@ aae
 aak
 aae
 aae
-aae
-aae
 aak
-tsi
-gMI
-gMI
-gMI
-gMI
-fpU
-hci
-fxU
-jGM
-hci
-hci
-jGM
-jGM
-jKl
-tsi
-dZP
-mKl
-iPf
-rvy
-aLF
-wjq
-oRj
-uWb
-aLF
-aLF
-aLF
-rga
-iPf
-hYg
-mKl
-tWa
-eix
-gJE
+aak
+ryF
+ryF
+lBb
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
+dMZ
+dMZ
+dMZ
+dMZ
+dMZ
+dMZ
+dMZ
+dMZ
+dMZ
+dMZ
+dMZ
+dMZ
+dMZ
+dMZ
+dMZ
+dMZ
+dMZ
+dMZ
+wwI
 waD
+onW
+rvy
+ajc
+ajc
+aBm
+aBm
+aLF
+aBm
+bZv
+oVq
+hEg
+fGU
+aTN
+hEg
+oVq
 tWa
+waD
+ajc
 lmM
-gdZ
-gdZ
-tWa
-aae
-aae
-aak
-aae
-aae
-aae
+tcz
+ffG
+psR
+bpy
+cHM
+bpy
+xdR
+tex
+oVq
 aaa
 "}
 (219,1,1) = {"
@@ -77851,11 +80904,11 @@ aae
 aae
 aae
 aae
+aak
+aak
 aae
 aae
-aae
-aae
-aae
+aak
 aae
 aae
 aae
@@ -77870,66 +80923,66 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-mTy
-mTy
-mTy
-mTy
-mTy
-mTy
-mTy
-aae
-aae
 aak
-ech
-gMI
-gMI
-gMI
-xsc
-tsi
-jHx
-tLt
-tLt
-tLt
-equ
-equ
-tLt
+ryF
+ryF
+ryF
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+dMZ
+qqb
+eJV
+eJV
+eJV
+eJV
+eJV
+eJV
+eJV
+eJV
+eJV
+eJV
+eJV
+eJV
+eJV
+eJV
 dqY
-dWd
-dZP
-mKl
-iPf
-omE
+dMZ
+saZ
+iGb
+onW
+oVq
+pHE
+aBm
+ajc
+ajc
 aLF
-dNs
-mst
-lcx
-aLF
-aLF
+aBm
 pBq
-nAc
-iPf
+oVq
+tbI
 iFV
 aTN
-tWa
-wpg
+pEf
+oVq
 xUW
-kFP
-tWa
-tWa
-tWa
-tWa
-tWa
-aak
-aak
-aae
-aak
-aae
-aae
+waD
+ajc
+lmM
+iiN
+ffG
+baR
+ffG
+bpy
+bpy
+ffG
+sgQ
+oVq
 aaa
 "}
 (220,1,1) = {"
@@ -78107,12 +81160,12 @@ aae
 aae
 aae
 aae
+aak
+aak
 aae
 aae
 aae
-aae
-aae
-aae
+aak
 aae
 aae
 aae
@@ -78128,65 +81181,65 @@ aae
 aak
 aak
 aak
-aae
-aae
-aak
-aae
-mTy
 ryF
-qGz
-qGz
-xCN
-cHM
+ryF
+ryF
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+dMZ
 mTy
-mTy
-mTy
-mTy
-kbd
-giF
-gMI
-gMI
-dqX
-tsi
-tsi
-tsi
-dXl
-tsi
-gkC
-hci
-hci
+dMZ
+dMZ
+dMZ
+dMZ
+dMZ
+dMZ
+dMZ
+dMZ
+dMZ
+dMZ
+dMZ
+dMZ
+dMZ
+dMZ
 jpP
-lEW
-iFV
-aTN
-iPf
+dMZ
+dMZ
+waD
+onW
 rvy
-aLF
+onW
 wjq
-oRj
-uWb
-aLF
-aLF
-aLF
-hbN
-iPf
-dZP
-bRg
-tWa
-kaf
+onW
+onW
+aBm
+ajc
+xrn
+oVq
+mQC
+cyI
+qio
+eix
+oVq
 pHE
-gJE
-tGp
+waD
+ajc
+lmM
 lpl
-lpl
-lpl
-tWa
-aae
-aae
-aae
-aak
-aae
-aae
+ffG
+kNk
+ffG
+xdR
+bpy
+qyr
+aGN
+oVq
 aaa
 "}
 (221,1,1) = {"
@@ -78331,31 +81384,12 @@ aae
 aae
 aaa
 aae
-aae
-aae
-aae
-aae
-aae
-aak
-aak
 aak
 aak
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aak
-aak
-aae
-aae
-aae
 aak
 aak
 aak
@@ -78370,6 +81404,25 @@ aae
 aae
 aae
 aae
+aak
+aak
+aae
+aae
+aae
+aak
+aak
+aak
+aae
+aae
+aae
+aae
+aak
+aak
+aae
+aak
+aae
+aae
+aak
 aae
 aae
 aae
@@ -78384,66 +81437,66 @@ aae
 aae
 aae
 aak
-aae
-aae
-aae
 aak
-aak
+lBb
+ryF
+ryF
+lBb
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+dMZ
 mTy
-szF
-szF
-szF
-pmW
-xTv
-lOD
-xTv
-uvy
-xTv
-kbd
+dMZ
+heQ
 uqG
+msJ
 gMI
-gMI
-gMI
-tsi
+sMP
+vzK
 cDu
 dFf
-uyj
-fse
-hci
-hci
-jGM
+cDu
+aly
+prD
+iOT
+jbY
 kHC
-rhX
-cHT
-ygU
-dSr
-wjq
-aLF
-beW
+dMZ
+dMZ
+waD
+onW
+oVq
+pLs
+oVq
 hcf
 gyV
-aLF
-aLF
-aLF
-ddN
-iPf
-dZP
-bRg
-tWa
-aBz
-xuo
-jpS
-qkN
-qyY
+yas
+rMI
+rMI
+oVq
+oVq
+oVq
+yas
+oVq
+oVq
+oVq
+waD
+onW
+oVq
 odn
 ffG
-tWa
-aae
-aak
-aae
-aae
-aae
-aae
+hFn
+xiQ
+xxf
+dky
+ffG
+xCN
+oVq
 aaa
 "}
 (222,1,1) = {"
@@ -78586,10 +81639,10 @@ aae
 aae
 aae
 aae
-aaa
 aae
 aae
-aae
+aak
+aak
 aae
 aae
 aak
@@ -78618,15 +81671,15 @@ aak
 aak
 aae
 aae
+aak
+aae
+aak
+aae
+aak
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
+aak
 aae
 aae
 aae
@@ -78639,68 +81692,68 @@ aak
 aae
 aae
 aae
+aak
+aak
 aae
-aak
-aae
-aae
-aak
-aak
-aak
+lBb
+ryF
+lBb
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+dMZ
 mTy
-szF
-szF
-szF
-etT
-wKh
-bUj
-wKh
-axq
-hgJ
-kbd
-gMI
+dMZ
+qju
+otJ
+utv
+dMZ
 aly
-aly
-aly
-tsi
+stH
 sMP
 vzK
-uyj
-fse
-jGM
+eLA
+eLA
+xsc
 hci
 hci
 xVp
 lEW
-dZP
-mKl
-iPf
-snn
-aLF
-aLF
-aLF
-aLF
-aLF
-aLF
-aLF
-uWb
-iPf
-dZP
-bRg
-tWa
-tWa
-tWa
-tWa
-tWa
-tWa
-tWa
-tWa
-tWa
-aae
-aak
-aae
-aae
-aae
-aae
+dMZ
+wKh
+vdQ
+vdQ
+dwx
+rvy
+pSt
+ajc
+ajc
+ajc
+ajc
+fcv
+oVq
+giF
+eoV
+mIf
+iUq
+oVq
+waD
+onW
+oVq
+oVq
+nua
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
 aaa
 "}
 (223,1,1) = {"
@@ -78873,25 +81926,13 @@ aae
 aae
 aak
 aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aak
+aak
 aak
 aak
 aae
+aae
+aak
 aae
 aae
 aae
@@ -78903,61 +81944,73 @@ aae
 aae
 aak
 aak
+aae
+aae
+aae
+aae
+aak
+aae
+aak
+aak
+lBb
+ryF
+lBb
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+dMZ
 mTy
-szF
-szF
-szF
-kjN
-xTv
-qbZ
-xTv
-gPb
-xTv
+dMZ
 kbd
-tsi
-tsi
-tsi
-tsi
-tsi
-teH
-vzK
+wtC
+oRj
+dMZ
+prD
+uyj
+uyj
+aIP
 uyj
 fse
-jGM
-hci
-hci
+hgJ
+dcl
+rPq
 jng
-tsi
-dZP
-mKl
-nSx
-iXN
-aLF
-aLF
-aLF
-aLF
-aLF
-aLF
-aLF
+qwx
+dMZ
+wKh
+vdQ
+vdQ
+dwx
+rvy
+aVt
+ajc
+ajc
+ajc
+ajc
 uWb
-iPf
+oVq
 hYg
-bRg
-uyb
+cWz
 ldv
-gXT
-gXT
-gXT
-sXj
+ldv
+oVq
+waD
+onW
+oVq
 mwb
-iGl
-uyb
-aak
-aak
-aae
-aae
-aae
-aae
+okh
+btm
+btm
+mwb
+eYn
+bUj
+bUj
+oVq
 aaa
 "}
 (224,1,1) = {"
@@ -79103,22 +82156,14 @@ aaa
 aaa
 aae
 aae
-aae
-aae
-aae
 aak
 aae
 aae
-aae
+aak
 aak
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
+aak
 aae
 aae
 aae
@@ -79141,6 +82186,14 @@ aak
 aae
 aae
 aae
+aak
+aae
+aak
+aak
+aak
+aae
+aae
+aak
 aae
 aae
 aae
@@ -79155,66 +82208,66 @@ aae
 aae
 aae
 aae
-aae
 aak
-aak
-aak
-aak
+lBb
+ryF
+lBb
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+dMZ
 mTy
-wwj
-qwx
-qwx
-kNk
-vnv
-mTy
-mTy
-ptD
-mTy
-mTy
-rRw
-cTh
-wtC
-maB
-tsi
+dMZ
+dMZ
+vQy
+dMZ
+dMZ
+oEO
 pII
-nIl
-mjl
-fse
-jGM
-pGM
-sXE
+pII
+pII
+pII
+pOy
+dMZ
+dMZ
+dMZ
 epj
-tsi
-dZP
-mKl
-iPf
+dMZ
+dMZ
+ptD
+rWA
 vdQ
-aLF
-aLF
+dwx
+rvy
 xQm
-aLF
-qyT
-aLF
-aLF
-uWb
-dSr
+cTr
+ajc
+ajc
+ajc
+lgh
+oVq
 gqF
 eIw
-hIc
-gXT
-gXT
-rGz
-rGz
-uyb
-jxG
+ldv
+ldv
+oVq
+wUV
+bNZ
+kjN
+ety
 pbB
-uyb
-aak
-aak
-aae
-aae
-aae
-aae
+aUl
+mwb
+mwb
+eYn
+bUj
+uvy
+oVq
 aaa
 "}
 (225,1,1) = {"
@@ -79360,22 +82413,13 @@ aaa
 aaa
 aae
 aae
-aae
-aae
-aae
+aak
 aak
 aae
-aae
+aak
 aak
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aak
 aae
 aae
 aae
@@ -79394,11 +82438,6 @@ aae
 aae
 aae
 aak
-aak
-aae
-aae
-aae
-aae
 aae
 aae
 aae
@@ -79406,6 +82445,20 @@ aae
 aae
 aak
 aak
+aae
+aak
+aak
+aae
+aae
+aak
+aae
+aae
+aae
+aae
+aae
+aae
+aak
+aak
 aak
 aak
 aae
@@ -79413,65 +82466,65 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-mTy
-mTy
-mTy
-mTy
-mTy
-mTy
-kcP
-uwS
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+dMZ
 oOV
-qqb
+eJV
 eJV
 rte
-rte
-rte
+dMZ
+dMZ
 hYB
-tsi
-tsi
-tsi
-tsi
-tsi
+pII
+pII
+pII
+pII
+fqc
+dMZ
 pAE
-pAE
 tsi
-tsi
-tsi
-iFV
-aTN
-iPf
-hOa
-aLF
-aLF
-aLF
-aLF
-aLF
-aLF
-aLF
-uWb
-iPf
-iFV
-fZM
-uyb
-tgR
-cZL
-rGz
-rGz
-uyb
+kHC
+dbO
+foM
+uQV
+vdQ
+vdQ
+qNj
+oVq
+lgh
+aTI
+ajc
+aQb
+gQu
+vxi
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+nIl
+ajc
+oVq
 qfa
 sHA
-uyb
-aak
-aak
-aae
-aak
-aae
-aae
+jak
+piz
+okh
+siG
+ibY
+ibY
+oVq
 aaa
 "}
 (226,1,1) = {"
@@ -79618,19 +82671,10 @@ aaa
 aae
 aae
 aae
+aak
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aak
 aae
 aae
 aae
@@ -79648,26 +82692,12 @@ aae
 aae
 aae
 aak
-aak
 aae
 aak
 aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aak
-aak
-aae
-aak
-aae
-aak
 aae
 aae
 aak
@@ -79678,57 +82708,80 @@ aae
 aae
 aae
 aak
+aae
+aae
+aae
+aae
+aae
+aae
 aak
-oVq
-dLM
-xTo
-jkI
-wsK
-oVq
-sWt
-okh
-bpy
+aak
+aak
+aae
+aak
+aae
+aak
+aae
+aae
+lBb
+ryF
+lBb
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+dMZ
+dMZ
+dMZ
+dMZ
+aAX
+dMZ
+dMZ
 oEO
-hYB
-sWt
-oVq
-jOM
-fta
+pII
+pII
+pII
+pII
+hSI
+dMZ
 euM
-euM
-fta
+dbO
 pXS
 gjY
-dZP
-mKl
-iPf
-cAN
-aLF
-foM
-tfh
-npF
-aLF
-aLF
-aLF
-uWb
-iPf
-hYg
-bRg
-bEX
-pvC
-sUJ
-gsU
-gXT
-uyb
-uyb
-uyb
-uyb
-aae
-aae
-aae
-aak
-aae
-aae
+msk
+xjW
+rWA
+vdQ
+rWA
+oVq
+oVq
+oVq
+hnd
+oVq
+oVq
+oVq
+oVq
+oVq
+fFB
+fFB
+fFB
+yer
+hgY
+aBm
+oVq
+oVq
+dLM
+xwF
+vOn
+mwb
+piz
+siG
+siG
+oVq
 aaa
 "}
 (227,1,1) = {"
@@ -79875,6 +82928,11 @@ aaa
 aae
 aae
 aae
+aak
+aae
+aae
+aae
+aak
 aae
 aae
 aae
@@ -79883,17 +82941,30 @@ aae
 aae
 aae
 aae
+aak
+aak
+aak
+aae
+aak
+aak
+aae
+aak
+aak
+aak
 aae
 aae
 aae
 aae
 aae
+aak
+aak
+aak
 aae
 aae
 aae
 aae
 aae
-aae
+aak
 aae
 aae
 aae
@@ -79909,83 +82980,65 @@ aak
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aae
-aae
-aae
-aae
-aae
-oVq
-gFk
-xTo
-jkI
-oxw
-oVq
-imX
+lBb
+lBb
+ryF
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+dMZ
 sWt
-sWt
-sWt
-tTH
-ryt
-oVq
-vaL
-onW
+pII
+pII
+pII
+pII
+hSI
+dMZ
 nzR
-nzR
-onW
-bRg
-oVq
-rCd
-rOj
-wBj
-fkv
-oEl
-oEl
-psR
-dJd
-iPU
-nPk
-oEl
-oJw
-iPf
-dZP
-bRg
-uyb
+ixe
+dSr
+dbO
+dMZ
+ptD
+rWA
 mEL
-ccI
-eRL
-gXT
-uyb
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+rWA
+vdQ
+vdQ
+dJd
+rWA
+rWA
+rWA
+rWA
+vdQ
+dJd
+vdQ
+rWA
+rWA
+rWA
+rLF
+ajc
+jHx
+oVq
+dWd
+nPk
+vca
+okh
+okh
+okh
+okh
+oVq
 aaa
 "}
 (228,1,1) = {"
@@ -80133,43 +83186,7 @@ aaa
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aak
-aak
-aae
-aae
-aak
-aae
-aae
-aae
-aae
 aae
 aae
 aae
@@ -80186,63 +83203,99 @@ aae
 aae
 aae
 aae
+aae
+aae
+aak
+aae
+aae
+aae
+aae
+aae
 aak
 aak
+aak
+aak
+aak
+aae
+aae
+aak
+aae
+aae
+aak
 aae
 aae
 aae
 aae
 aae
+aae
+aae
+aae
+aae
+aak
+aak
+aak
+aae
+aae
+aae
+ryF
+lBb
+lBb
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+dMZ
+dMZ
 oVq
-kRz
-xTo
-vBu
-oOV
 oVq
-eBc
-rmQ
-cEz
-mng
-tTH
-cvx
-rgS
-wtQ
-yke
-rWu
-ihr
-pLs
-bRg
-gjY
-dZP
-mKl
-iPf
-iPf
-lBs
-dwx
-dwx
-dwx
-iPf
-iPf
-iPf
-iPf
-iPf
-dZP
-mKl
-uyb
-lii
-pif
+oVq
+oVq
+oVq
+dMZ
+dMZ
+dMZ
+dMZ
+dMZ
+dMZ
+uQV
 mEL
-gXT
-uyb
-aae
-aae
-aak
-aae
-aae
-aae
-aae
-aae
-aae
+dMj
+rWA
+vdQ
+dwx
+oVq
+lNq
+rWA
+vWC
+rWA
+cAT
+oVq
+mfA
+lcf
+lii
+hOt
+gkY
+onW
+ayy
+oVq
+wAJ
+sxz
+tZW
+okh
+wEv
+uwS
+vxO
+oVq
 aaa
 "}
 (229,1,1) = {"
@@ -80393,6 +83446,15 @@ aae
 aae
 aae
 aae
+aak
+aae
+aae
+aae
+aae
+aae
+aak
+aak
+aae
 aae
 aae
 aae
@@ -80408,15 +83470,6 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aak
 aak
 aak
@@ -80427,13 +83480,13 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aak
+aak
+aak
+aak
+aak
+aak
+aak
 aae
 aak
 aak
@@ -80441,65 +83494,65 @@ aak
 aak
 aae
 aae
-aae
-aae
-aae
-aak
-aak
-aae
-aae
-aae
-aae
+lBb
+lBb
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
 oVq
-mLk
-xoI
-xoI
-tZW
-oVq
-sWt
-sWt
-sWt
-sWt
+wZq
 tTH
 rRw
 oVq
-oVq
-oVq
+mqg
+vnv
 iYm
-sQF
+dFC
 aIM
 dDm
 oVq
-hYg
-mKl
-iPf
+aaO
+uQV
+mEL
 qzt
 hFj
-gXg
-jiV
-aEY
+vdQ
+dwx
+oVq
 fVI
-fVI
-fVI
-rUK
-iPf
-dZP
-mKl
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-aae
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+rWA
+krv
+rWA
+aqo
+oVq
+eDN
+hRv
+dMj
+lnQ
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+nua
+oVq
+oVq
+oVq
+oVq
+oVq
 aaa
 "}
 (230,1,1) = {"
@@ -80648,7 +83701,7 @@ aae
 aae
 aae
 aae
-aae
+aak
 aae
 aae
 aae
@@ -80690,11 +83743,7 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
+aak
 aae
 aae
 aae
@@ -80702,61 +83751,65 @@ aae
 aae
 aae
 aak
-aak
-aak
-aak
-aae
-aae
-dMZ
-dMZ
-dMZ
-dMZ
-dMZ
-dMZ
-dMZ
-sWt
-aNu
-rRw
-tTH
+ryF
+lBb
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
+hOa
 dFC
-oVq
-uQM
-qju
+dFC
+qat
+dFC
+jOo
 iNk
-iNk
-onW
-dDm
-oVq
-hYg
-mKl
-iPf
+gQo
+jOo
+nzp
+wsK
+oSF
+uQV
+mEL
 qUn
 tHm
-tHm
-tHm
-aLF
-aLF
-aLF
-aLF
-uWb
-iPf
-dZP
-mKl
-gSv
-gSv
+rWA
+dwx
+oVq
+qmp
+rWA
+jbj
+rWA
+nTS
+oVq
+mEL
+hUj
+qVd
 aPj
-quH
-quH
-quH
-quH
-quH
-quH
-quH
-quH
-quH
-quH
-quH
-quH
+eIt
+bSF
+ibf
+iXN
+pXb
+ybK
+yfD
+jfa
+oLs
+tbp
+pmH
+vef
 aaa
 "}
 (231,1,1) = {"
@@ -80905,12 +83958,34 @@ aae
 aak
 aak
 aae
+aak
+aae
+aae
+aak
+aae
+aae
+aak
+aak
+aae
+aak
 aae
 aae
 aae
 aae
 aae
 aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aak
+aak
 aak
 aae
 aae
@@ -80930,90 +84005,68 @@ aae
 aae
 aae
 aae
-aae
-aak
-aak
 aak
 aae
-aae
 aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aak
-aae
-aae
-aae
-dMZ
-iko
-dIo
-mqg
-dIo
-mqg
-dMZ
-sWt
-sWt
-sWt
-tTH
-sWt
+lBb
+lBb
+ryF
+lBb
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
 oVq
-uQM
-qGw
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+qPd
+oVq
+uPJ
+jOo
+dFC
 eVM
-eVM
-wce
+dFC
 lAN
-oVq
+wsK
 oSF
-aTN
-iPf
+iBq
+rWA
 sNC
-oEl
-sBv
-nPi
-gTT
-ceX
-ceX
-oEl
-oJw
-iPf
-iFV
+wBd
+rWA
+dwx
+oVq
+oVq
+vef
+oVq
+oVq
+oVq
+oVq
 bRg
-gSv
+hUj
 dMj
-quH
+sEa
 eIt
 tnm
-jCu
-rgE
-vXs
-aPj
+yfD
+yfD
+yfD
+dmc
 pmb
-rGt
 dmc
 dmc
 dmc
-quH
+pmb
+oVq
 aaa
 "}
 (232,1,1) = {"
@@ -81169,39 +84222,9 @@ aae
 aae
 aae
 aae
-aae
-aae
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aak
 aae
 aak
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aae
 aae
 aae
@@ -81221,56 +84244,86 @@ aae
 aae
 aak
 aak
-dMZ
-vYD
-lcf
-hpP
-vhO
-mpk
-dMZ
+aae
+aak
+aak
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aak
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aak
+lBb
+lBb
+ryF
+ryF
+lBb
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
 oVq
+nqg
+nPD
+hbv
 oVq
 jju
 hOV
+qxD
 oVq
-oVq
-oVq
-oVq
-oVq
-oVq
-oVq
-oVq
-oVq
-hYg
-mKl
-iPf
-iPf
-iPf
-iPf
-iPf
-iPf
-iPf
-iPf
-iPf
-iPf
-iPf
+qPZ
+byQ
+bot
+etT
+dlD
+wDj
+wsK
+qNj
+xJG
+hOt
+hOt
+lii
+pMJ
+rWA
+vXx
+qzt
+nEP
+ukZ
+ukZ
+vef
 bhF
-bNZ
-wSs
-nTS
-xMh
+cvx
+hUj
+rWA
+qZg
+eIt
 aiq
-aiq
-aiq
-wOH
-aiq
-hjR
-aiq
-jUU
+dmc
 yfD
-hEg
-xxf
-quH
+yfD
+pmb
+yfD
+yfD
+yfD
+pmb
+dmc
+oVq
 aaa
 "}
 (233,1,1) = {"
@@ -81446,20 +84499,21 @@ aae
 aae
 aae
 aae
-aae
-aak
-aae
 aak
 aak
 aae
-aae
-aae
-aae
+aak
 aak
 aae
 aae
 aae
 aae
+aak
+aae
+aae
+aae
+aae
+aak
 aae
 aae
 aae
@@ -81467,67 +84521,66 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-dMZ
-sEc
-duV
-hpP
-mpk
-cdu
-tpb
-ajc
-tau
-fta
+aak
+ryF
+ryF
+lBb
+ryF
+ryF
+lBb
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
+wpg
+qxD
+tsu
+oVq
+qHQ
 qxD
 mWZ
-frx
+oVq
 pGE
-pGE
-pGE
+mLk
+bCp
 pjX
 bCp
 fta
-fta
-yer
+cRX
+dbG
 hYQ
-fta
+rWA
+rWA
+vdQ
+iBq
+vdQ
+vXx
+sNC
+oVq
 aVj
-dWc
-dWc
-dWc
-dWc
-dWc
-dWc
-dWc
 aVj
-dWc
+oVq
 yer
-onW
-gSv
-gSv
-quH
-hNm
-ejL
-aTZ
-ejL
-cgy
-quH
-aew
+cvx
+hUj
+vdQ
+vdQ
+oVq
+oVq
+oIL
+djF
+pmb
+dmc
+yfD
 dKt
-ejL
-jfa
-ejL
-quH
+fpZ
+yfD
+ihr
+oVq
 aaa
 "}
 (234,1,1) = {"
@@ -81680,25 +84733,25 @@ aak
 aak
 aak
 aae
-aae
 aak
 aak
-aae
 aak
-aak
-aae
-aae
-aae
 aak
 aak
 aak
 aae
 aae
 aae
+aak
+aak
+aak
 aae
 aae
 aae
-aae
+aak
+aak
+aak
+aak
 aae
 aae
 aae
@@ -81717,6 +84770,7 @@ aae
 aae
 aae
 aae
+aak
 aae
 aae
 aae
@@ -81724,67 +84778,66 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-dMZ
-aAb
-hpP
-sbH
-hpP
-mpk
+aak
+ryF
+lBb
+lBb
+lBb
+ryF
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
+oVq
 soO
-onW
-gFh
-gFh
-gFh
-wce
-gYI
-gFh
-gFh
-gFh
-qVd
-lnQ
-ydD
-hQw
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
 lhi
+lhi
+lhi
+lhi
+kcP
 hQw
-hQw
-wQJ
-hQw
-hQw
-hQw
-hQw
-hQw
-hQw
+vdQ
+vdQ
+vdQ
+kEi
 ydD
-pBx
 hOt
-oXy
-ajc
-ajc
-onW
-quH
-hNm
-ejL
+hOt
+hOt
+qmd
+kSu
+dbG
+pmW
+dwx
+eIt
 aTZ
-ejL
-nzp
-quH
-aew
-ejL
-ejL
+eBc
+pmb
+dmc
+yfD
+dKt
+avf
 uWI
 ejL
-quH
+oVq
 aaa
 "}
 (235,1,1) = {"
@@ -81935,38 +84988,9 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
 aak
 aae
 aak
-aae
-aae
-aae
-aak
-aae
-aae
-aak
-aak
-aae
-aak
-aak
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aak
 aak
 aak
@@ -81974,6 +84998,11 @@ aae
 aae
 aae
 aak
+aae
+aae
+aak
+aak
+aae
 aak
 aak
 aak
@@ -81991,57 +85020,81 @@ aae
 aae
 aae
 aae
+aak
+aak
+aak
 aae
-dMZ
-sEc
-duV
-hpP
-mpk
+aae
+aae
+aak
+aak
+aak
+aak
+aae
+aae
+aae
+aae
+aak
+aak
+ryF
+lBb
+lBb
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
 cdu
-kRQ
-onW
+dFC
+fpU
 nqe
-fta
-fta
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-jRx
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-seX
-uyb
-uyb
+qpr
+gXT
+bCp
+bEk
+sEK
+afv
+hyi
+wSs
+jfH
+smk
+oVq
+mEL
+mEL
+vdQ
+ddN
+oDv
+tsK
+dbG
+dbG
+rgS
+qmd
+hYQ
+rWA
+rWA
 gSv
-ajc
-quH
-hNm
-ejL
-aTZ
-ejL
+gSv
+gSv
+rWA
+hUj
+oSF
+eIt
+loz
+eBc
 cgy
-quH
-aew
-ejL
-ejL
-quH
+lOD
+utQ
+dKt
+ceF
+jqz
 qtd
-quH
+oVq
 aaa
 "}
 (236,1,1) = {"
@@ -82193,51 +85246,22 @@ aae
 aae
 aae
 aae
-aae
-aae
-aak
-aae
-aae
-aae
-aak
-aak
-aak
-aak
-aak
-aak
-aae
-aak
-aak
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aak
-aae
 aak
 aae
 aak
 aak
 aae
 aae
+aak
+aak
+aak
+aak
+aak
+aak
 aae
-aae
+aak
+aak
+aak
 aak
 aae
 aae
@@ -82249,56 +85273,85 @@ aae
 aae
 aae
 aae
-dMZ
-vYD
-sMO
-hpP
-sEK
-mpk
-dMZ
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aak
+aak
+aae
+aak
+aae
+aak
+aak
+aae
+aae
+aae
+aae
+aak
+aak
+ryF
+ryF
+lBb
+ryF
+lBb
+ryF
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
+cdu
 jOo
-uyb
-uyb
-uyb
-uyb
-aqo
-gXT
-oGI
-gXT
-gXT
-hDv
+jOo
+jOo
+jOo
+rDp
+pGM
+oVq
+eUW
+ajc
+oVq
+xwg
+waD
 pxF
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-rGz
-pmx
-frr
-pmx
-uyb
-ldv
-gXT
-gXT
-gXT
-uyb
-gSv
-unO
-quH
-hNm
-ejL
+oVq
+rWA
+mEL
+mEL
+rWA
+oDv
+stF
+mEL
+mEL
+hUj
+rWA
+vdQ
+vdQ
+bZr
+rWu
+aEY
+oGI
+mfA
+cYU
+hOt
+ygU
 jbR
-ejL
-cgy
-quH
+qGw
+dmc
+ayZ
 aew
-ejL
-gUG
-quH
+dKt
+pmb
+qtd
 ltf
-quH
+oVq
 aaa
 "}
 (237,1,1) = {"
@@ -82450,7 +85503,7 @@ aae
 aae
 aae
 aae
-aae
+aak
 aae
 aae
 aak
@@ -82466,96 +85519,96 @@ aae
 aae
 aae
 aak
+aak
+aak
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aak
+aak
+aae
+aak
+aak
 aae
 aak
 aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aak
 aak
-aae
-aak
-aak
-aae
-aak
-aae
-aae
-aae
-aae
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-dMZ
-sWg
-hSI
+ryF
+lBb
+lBb
+ryF
+lBb
+ryF
+ryF
+lBb
+lBb
+ryF
+ryF
+ryF
+ryF
+oVq
 uUY
-hSI
-uUY
-dMZ
-uyb
-uyb
+dFC
+jOo
+cBX
 cBX
 niT
 rFX
-gXT
-mEL
-ppn
-kze
-kze
-hnd
-mlD
-uyb
-gxX
-tWe
-rGz
-hsV
-uyb
-rGz
-mEL
-mEL
-qyr
-uyb
-gXT
-gXT
-rGz
-rGz
-uyb
 oVq
+ieX
+ajc
+kze
+oIb
+hgY
+mlD
+oVq
+rWA
+tWe
+mEL
+rWA
+oDv
+tlN
+mEL
+mEL
+hUj
+rWA
+vdQ
+dwx
+ljv
+sSo
+nKw
+sEc
 psa
+rWA
+vdQ
 quH
-quH
-quH
-quH
-quH
-quH
-quH
-quH
-quH
-quH
-quH
-quH
-quH
+dmc
+yfD
+cgy
+jjV
+jGW
+dKt
+ceF
+tjj
+yhd
+oVq
 aaa
 "}
 (238,1,1) = {"
@@ -82708,9 +85761,9 @@ aae
 aae
 aae
 aae
+aak
 aae
-aae
-aae
+aak
 aae
 aak
 aak
@@ -82724,17 +85777,8 @@ aak
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aak
+aak
 aae
 aae
 aae
@@ -82742,8 +85786,6 @@ aae
 aae
 aae
 aak
-aak
-aae
 aae
 aae
 aae
@@ -82762,57 +85804,68 @@ aae
 aae
 aae
 aae
+aae
 aak
-dMZ
-dMZ
-dMZ
-dMZ
-dMZ
-dMZ
-dMZ
-uyb
+aak
+ryF
+ryF
+ryF
+ryF
+lBb
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
+oVq
+oVq
+oVq
 rJw
-yfr
+jOo
 rDp
-mEL
-mEL
-mEL
-jov
-sUJ
-sUJ
-hnd
-gXT
-uyb
+wmQ
+oVq
+wLq
+ajc
+skf
+ajc
+hgY
+jwC
+oVq
 qtK
-kze
-jxG
-jxG
+vdQ
+rWA
+rWA
 qMG
-rGz
-oLs
+rJh
 mEL
-mEL
-uyb
-tgR
-cZL
-rGz
-rGz
-uyb
+oQC
+bTe
+rWA
+vdQ
+dwx
+gYC
+sSo
+tOy
 coH
-gJE
-uYW
-fLs
-ibf
-tWa
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+psa
+rWA
+oSF
+eIt
+gxX
+yfD
+yfD
+pmb
+pmb
+dmc
+avf
+mlg
+gkC
+oVq
 aaa
 "}
 (239,1,1) = {"
@@ -82983,14 +86036,14 @@ aae
 aae
 aae
 aae
+aak
+aae
+aak
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
+aak
+aak
 aae
 aae
 aae
@@ -83011,65 +86064,65 @@ aak
 aak
 aak
 aak
-aak
-aak
-aae
-aae
-aae
-aae
-aae
-aak
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-uyb
+ryF
+ryF
+lBb
+ryF
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
 msW
-rgG
-jxG
-jxG
-mVc
-sUJ
-sUJ
-jxG
-jxG
-xjW
-gXT
-uyb
+bCp
+tLt
+bsm
+oVq
+onW
+rgE
+ppq
+fxU
+hgY
+eWJ
+oVq
 qrP
 myl
 llc
-mEL
-uyb
-rGz
-jxG
-mEL
+gei
+mjl
+fPE
+rWA
+oQC
 hUj
-bEX
-pvC
-qPd
-hVT
-gXT
-uyb
-gJE
-gJE
-gJE
+vdQ
+vdQ
+vdQ
+qNj
+rCd
+fVC
+vBu
+qNj
+vdQ
 aRA
-pMJ
-tWa
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+eIt
+aJI
+pmb
+dmc
+pmb
+yfD
+dmc
+hjR
+tpb
+hAz
+oVq
 aaa
 "}
 (240,1,1) = {"
@@ -83242,12 +86295,12 @@ aae
 aae
 aae
 aae
+aak
+aak
+aak
 aae
-aae
-aae
-aae
-aae
-aae
+aak
+aak
 aae
 aae
 aae
@@ -83268,65 +86321,65 @@ aak
 aak
 aak
 aak
-aak
-aak
-aae
-aae
-aae
-aae
-aae
-aak
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-uyb
-fpZ
+lBb
+ryF
+lBb
+ryF
+ryF
+lBb
+ryF
+ryF
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
 rgG
-jxG
-jxG
-mVc
+rgG
+dFC
+mme
+oVq
 sUJ
-jxG
-jxG
-mEL
+onW
+cRP
+ajc
 twY
-owd
-uyb
-gXT
-xBH
-jxG
-qmd
-uyb
-rGz
-rGz
-yaj
-rGz
-uyb
+wSs
+jKl
 dbG
-sVa
-eRL
-gXT
-uyb
+qmd
+sMy
+qmd
+dbG
+dbG
+hOt
+lii
+rGz
+dbG
+dbG
+dbG
+dbG
+aDq
+mng
 kJP
-gJE
-gJE
+mEL
+dMj
 qNj
-pMJ
-tWa
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+oVq
+xDw
+aDt
+dmc
+dmc
+yfD
+pmb
+dmc
+dmc
+axh
+oVq
 aaa
 "}
 (241,1,1) = {"
@@ -83478,9 +86531,9 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
+aak
+aak
+aak
 aae
 aae
 aae
@@ -83525,65 +86578,65 @@ aae
 aae
 aae
 aae
-aae
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-uyb
-msW
+lBb
+ryF
+ryF
+ryF
+ryF
+lBb
+ryF
+ryF
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
 rgG
-jxG
-mEL
-cRP
+rgG
+dFC
+pBx
+oVq
 sUJ
-sUJ
-jxG
-mEL
-mEL
-gXT
-nvm
-gXT
-jxG
-jxG
+chv
+cOG
+sVa
+ajc
+nSx
+oVq
+dwx
+rWA
+iBq
 wWo
-uyb
-cLp
-uyb
-uyb
-uyb
-uyb
-lii
-mEL
+vdQ
+rWA
+rWA
+rWA
+mHK
+rWA
+gSv
+rHV
 gQf
-gXT
-uyb
-wDj
-gJE
-gJE
-fLs
-gQo
-tWa
-aae
-aae
-aae
-aae
-aak
-aak
-aae
-aae
-aae
+iBq
+gSv
+rWA
+dMj
+mEL
+dwx
+oVq
+gnJ
+dRJ
+dmc
+pmb
+yfD
+dKt
+pmb
+pmb
+yfD
+oVq
 aaa
 "}
 (242,1,1) = {"
@@ -83735,9 +86788,9 @@ aae
 aae
 aae
 aae
+aak
 aae
-aae
-aae
+aak
 aae
 aae
 aae
@@ -83782,65 +86835,65 @@ aae
 aae
 aae
 aae
-aae
-aak
-aae
-aae
-aae
-aae
-aak
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-uyb
-cBX
-yfr
-qGX
-mEL
-mEL
-jxG
-sUJ
-xxs
-jov
-mEL
-gXT
-uyb
-gXT
-mEL
+lBb
+ryF
+ryF
+ryF
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
+rgG
+rgG
+dFC
+sMO
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+qNj
+rWA
 iBq
 rWA
-uyb
-otJ
-udp
-ggS
-xui
-uyb
-uyb
-fcF
-uyb
-uyb
-uyb
-jxe
-gJE
+vdQ
+rWA
+rWA
+rWA
+oVq
+rMI
 vNK
-gJE
-gJE
-tWa
-aae
-aak
-aak
-aae
-aak
-aak
-aae
-aae
-aae
+vNK
+vNK
+ecF
+vef
+jxe
+vNK
+vNK
+vNK
+oVq
+iPU
+ioA
+oVq
+gUu
+dmc
+pmb
+wOH
+cdV
+vef
+oVq
 aaa
 "}
 (243,1,1) = {"
@@ -83992,9 +87045,9 @@ aae
 aae
 aae
 aae
+aak
 aae
-aae
-aae
+aak
 aae
 aae
 aae
@@ -84039,65 +87092,65 @@ aae
 aak
 aak
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-uyb
-uyb
-rJw
-uQV
-geO
-sMy
-jxG
-oMu
-oMu
-oMu
-mEL
-djF
-uyb
-dSb
-xJG
-xdR
-vOB
-uyb
-otJ
-gkY
+ryF
+ryF
+jUU
+ryF
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+vdQ
+rWA
+iBq
+wWo
+rWA
+wWo
+rWA
 aKk
-tNq
-uyb
+kFP
+dQF
 dAo
-jxG
-mEL
-mEL
-uyb
-tWa
+dQF
+dQF
+fcF
+qFr
+hfP
 mdo
-tWa
-wNJ
-tWa
-tWa
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+mdo
+dAo
+oVq
+oVq
+oVq
+oVq
+oVq
+gxc
+gxc
+oVq
+oVq
+oVq
+oVq
 aaa
 "}
 (244,1,1) = {"
@@ -84249,6 +87302,7 @@ aae
 aak
 aae
 aae
+aak
 aae
 aae
 aae
@@ -84260,15 +87314,14 @@ aae
 aae
 aae
 aae
+aak
+aak
+aak
+aak
+aak
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aak
+aak
 aae
 aae
 aae
@@ -84295,66 +87348,66 @@ aae
 aae
 aae
 aae
-aak
 aae
-aae
-aak
-aak
-aae
-aae
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-uyb
-uyb
-uyb
-uyb
+ryF
+jUU
+jUU
+lBb
+jUU
+lBb
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
 nqg
-rGz
+nPD
 hbv
+oVq
+dvB
 gXT
-gXT
-gXT
-gUu
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
+bCp
+oXy
+dbG
+qmd
+hYQ
+rWA
+rWA
+rWA
+vdQ
+vdQ
+kFP
+dQF
 iXJ
-jxG
-jxG
-jxG
-uyb
-fLs
-fLs
-tWa
-fLs
-fLs
-tWa
-aae
-aae
-aak
-aak
-aae
-aae
-aae
-aae
-aae
+cLp
+iXJ
+fcF
+wMy
+hfP
+iXJ
+cLp
+iXJ
+dQF
+oVq
+xDG
+dFC
+xDG
+dFC
+dFC
+jpS
+gFk
+hpP
+oVq
 aaa
 "}
 (245,1,1) = {"
@@ -84506,33 +87559,15 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
+aak
 aak
 aak
 aak
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aae
-aae
-aae
-aae
 aak
 aak
 aak
-aae
 aae
 aak
 aak
@@ -84542,19 +87577,7 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aak
-aae
-aae
-aae
 aak
 aae
 aae
@@ -84562,6 +87585,8 @@ aae
 aak
 aak
 aak
+aae
+aae
 aak
 aak
 aae
@@ -84573,45 +87598,73 @@ aae
 aae
 aae
 aae
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
-uyb
+aae
 aae
 aae
 aae
 aae
 aae
 aak
-aak
 aae
-aae
-uyb
-wlK
-jxG
-lmq
+ryF
+ryF
+ryF
+lBb
+lBb
+lBb
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
+qxD
+qxD
+cZL
+oVq
+dvB
+ech
+dFC
+oVq
+qNj
+rWA
+uEA
+tTa
+vdQ
+ugu
+vdQ
+ugu
+kFP
+dQF
+dQF
+mdo
+mdo
 azL
 uyb
 hfP
 dQF
-tWa
 dQF
-utv
-tWa
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+dQF
+dQF
+oVq
+dFC
+fml
+fml
+fml
+dFC
+tfh
+gFk
+gFk
+oVq
 aaa
 "}
 (246,1,1) = {"
@@ -84766,60 +87819,14 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aak
-aae
-aae
-aae
-aae
-aae
-aae
+aak
+aak
+aak
 aak
 aae
 aae
 aak
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aae
-aae
-aak
-aae
-aae
-aae
-aae
-aae
-aae
 aae
 aae
 aae
@@ -84835,40 +87842,86 @@ aae
 aae
 aae
 aak
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aae
 aae
 aak
 aak
 aae
-uyb
-uyb
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+ryF
+ryF
+ryF
+ryF
+lBb
+ryF
+ryF
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
+wpg
+qxD
+aei
+oVq
+dvB
+wTx
+byQ
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+kFP
+fWB
+unv
 cLp
+iXJ
+azL
 uyb
-uyb
-uyb
-tWa
-tWa
-tWa
-tWa
-tWa
-tWa
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aae
-aae
+hfP
+iXJ
+cLp
+unv
+uwD
+oVq
+dFC
+qcd
+qcd
+qcd
+dFC
+beo
+oJw
+jVE
+oVq
 aaa
 "}
 (247,1,1) = {"
@@ -85023,7 +88076,7 @@ aae
 aae
 aae
 aae
-aae
+aak
 aae
 aae
 aae
@@ -85067,65 +88120,65 @@ aae
 aae
 aak
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aak
-aak
-aae
-aae
-aae
-aae
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+lBb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
+oVq
+reU
+oVq
+oVq
+oVq
+oVq
+cFq
+oVq
+jlT
+xTv
+jOo
+qkN
+vhO
+aAv
+eDg
+oVq
+oVq
 tNq
-otJ
-otJ
-jdX
-uyb
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+tNq
+tNq
+tNq
+tsV
+aRp
+hIc
+ehp
+ehp
+ehp
+ehp
+oVq
+dFC
+dFC
+dFC
+dFC
+dFC
+xuo
+oJw
+ktb
+oVq
 aaa
 "}
 (248,1,1) = {"
@@ -85278,6 +88331,10 @@ aae
 aae
 aae
 aae
+aak
+aae
+aae
+aak
 aae
 aae
 aae
@@ -85291,11 +88348,7 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
+aak
 aak
 aak
 aae
@@ -85323,66 +88376,66 @@ aae
 aae
 aae
 aak
-aak
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aae
-aae
-aae
-aae
-aae
-aak
-aak
-aak
-aae
-aae
-aae
-aae
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-uyb
-fml
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
+sBv
+dFC
+irV
+oVq
+sBv
+sBv
+ech
+oVq
+cHT
+jOo
+pXZ
+qkN
+hLB
+qkN
+gGI
+nPi
+frr
+knT
+ggS
 ggS
 vWk
-uyb
-aae
-aae
-aak
-aak
-aak
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aae
-aae
+tsV
+aOm
+hIc
+bxV
+ijY
+mfU
+vWk
+oVq
+dFC
+fml
+fml
+fml
+dFC
+bkS
+oJw
+ktb
+oVq
 aaa
 "}
 (249,1,1) = {"
@@ -85538,9 +88591,9 @@ aak
 aae
 aae
 aae
-aae
-aae
-aae
+aak
+aak
+aak
 aae
 aae
 aae
@@ -85581,65 +88634,65 @@ aae
 aae
 aae
 aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aak
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aak
-aak
-aae
-aae
-aae
-aae
-aak
-aak
-aak
-aak
-aak
-aak
-aae
-aak
-aae
-aae
-aae
-aae
-uyb
-uyb
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
+sBv
+dFC
+sBv
+oVq
+gog
+dFC
+ech
+oVq
+cHT
+xWy
+rCL
+yiE
+hLB
+qkN
+hsl
+rzF
+frr
+vWk
 jVN
-uyb
-uyb
-aae
-aae
-aae
-aak
-aak
-aae
-aae
-aae
-aae
-aae
-aak
-aae
-aae
-aak
-aae
-aae
+jVN
+avY
+tsV
+yix
+hIc
+hIc
+hIc
+hIc
+hIc
+jxe
+dFC
+qcd
+qcd
+qcd
+dFC
+xuo
+oJw
+gFk
+oVq
 aaa
 "}
 (250,1,1) = {"
@@ -85788,55 +88841,9 @@ aae
 aae
 aae
 aae
-aae
 aak
 aak
 aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aak
-aae
-aae
-aae
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aak
-aae
-aae
-aak
-aak
-aak
-aae
-aae
-aae
-aae
-aae
 aak
 aae
 aae
@@ -85847,8 +88854,21 @@ aae
 aak
 aak
 aak
+aak
+aak
+aak
+aak
+aak
+aak
+aak
+aak
+aae
+aak
+aak
 aae
 aae
+aae
+aak
 aae
 aae
 aae
@@ -85862,41 +88882,74 @@ aak
 aak
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aak
+aak
 aak
 aae
 aae
 aae
-aak
-aak
-uyb
+aae
+aae
+aae
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
+ijt
+dFC
+gog
+oVq
+msW
+bCp
+tLt
+oVq
+cHT
+fhh
+ceX
+qkN
+hLB
+qkN
+ouS
+sbH
+mWI
+sBc
 nbJ
-uyb
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aae
-aae
-aae
-aae
-aae
+nbJ
+nbJ
+jwf
+hIc
+jdX
+sIH
+jqN
+vWk
+biK
+oVq
+dFC
+dFC
+dFC
+dFC
+dFC
+xuo
+oJw
+ktb
+oVq
 aaa
 "}
 (251,1,1) = {"
@@ -86044,77 +89097,9 @@ aae
 aae
 aae
 aae
-aae
-aae
 aak
 aak
 aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aak
-aae
-aae
-aae
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aak
-aae
-aak
-aak
-aak
-aak
-aae
-aae
-aae
-aae
-aak
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aak
-aak
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aak
 aak
 aae
@@ -86134,26 +89119,94 @@ aae
 aae
 aae
 aae
+aae
+aak
+aak
+aae
+aae
+aae
+aak
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aak
+aak
+aae
+aak
+aak
+aak
+aak
+aae
+aae
+aae
+aae
+aak
+aae
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
+qpr
+dFC
+dFC
+snn
+dFC
+jtQ
+qGY
+oVq
+oVq
+oVq
+oVq
+oVq
+jCu
+oVq
+pwv
+rzF
+frr
+iRD
+vWk
+vWk
+qpr
+kRS
+qpr
+jOM
+fNX
 uyb
-uyb
-uyb
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aak
-aak
-aak
-aae
-aae
-aae
-aae
+vWk
+hIc
+oVq
+dFC
+fml
+fml
+fml
+dFC
+xMo
+oJw
+jVE
+oVq
 aaa
 "}
 (252,1,1) = {"
@@ -86299,66 +89352,11 @@ aaa
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aak
 aak
 aak
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aak
 aak
 aak
 aae
@@ -86376,15 +89374,6 @@ aae
 aae
 aae
 aae
-aak
-aak
-aak
-aak
-aak
-aak
-aae
-aae
-aak
 aae
 aae
 aae
@@ -86394,23 +89383,87 @@ aae
 aae
 aae
 aae
-aak
-aae
-aae
-aak
-aak
-aak
 aae
 aae
 aae
 aae
 aae
-aak
 aae
 aae
 aae
 aae
 aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
+wZq
+dFC
+dFC
+oVq
+pif
+vfZ
+qGY
+oVq
+uGa
+qxD
+jZb
+vsR
+jOo
+oVq
+fyE
+vXs
+frr
+gok
+gok
+vWk
+fXa
+ech
+dlz
+dFC
+gdP
+uyb
+vWk
+biK
+oVq
+qiz
+qcd
+qcd
+qcd
+dFC
+soA
+gFk
+gFk
+oVq
 aaa
 "}
 (253,1,1) = {"
@@ -86609,65 +89662,65 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aak
-aae
-aae
-aae
-aae
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aae
-aae
-aae
-aae
-aae
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
+oVq
+dIo
+dIo
+oVq
+fhh
+gPy
+qGY
+oVq
+qkE
+qxD
+oVq
+smj
+dIo
+oVq
+jkr
+npF
+oVq
+xBA
+rdL
+vWk
+dFC
+vcF
+jOo
+fhh
+ccI
+uyb
+kDq
+hIc
+gxz
+fhh
+dFC
+fhh
+dFC
+dFC
+jpS
+gFk
+hpP
+oVq
 aaa
 "}
 (254,1,1) = {"
@@ -86866,65 +89919,65 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+ryF
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
+oVq
 aaa
 "}
 (255,1,1) = {"

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -517,14 +517,11 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-<<<<<<< Updated upstream
 "acU" = (
 /obj/item/circuitboard/machine/ore_redemption,
 /obj/structure/frame/machine,
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
-=======
->>>>>>> Stashed changes
 "aei" = (
 /obj/machinery/door/window/left/directional/north,
 /obj/machinery/shower{
@@ -1121,7 +1118,6 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
-<<<<<<< Updated upstream
 	},
 /obj/machinery/conveyor_switch/oneway{
 	id = "QMUnload"
@@ -1131,17 +1127,6 @@
 "aAk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-=======
-	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "QMUnload"
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood)
-"aAk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
->>>>>>> Stashed changes
 /obj/machinery/camera/autoname{
 	dir = 10;
 	name = "North Facing Camera";
@@ -1337,21 +1322,12 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
-<<<<<<< Updated upstream
 	},
 /area/f13/brotherhood)
 "aJI" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
-=======
-	},
-/area/f13/brotherhood)
-"aJI" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
->>>>>>> Stashed changes
 /obj/item/stack/sheet/prewar/five,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
@@ -1479,7 +1455,6 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "aQB" = (
-<<<<<<< Updated upstream
 /turf/open/floor/pod/light,
 /area/f13/brotherhood)
 "aRp" = (
@@ -1494,26 +1469,6 @@
 	layer = 3
 	},
 /obj/structure/window/reinforced{
-=======
-/obj/machinery/light,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/brotherhood)
-"aRp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
->>>>>>> Stashed changes
 	color = "#3e3d42"
 	},
 /obj/structure/flora/ausbushes/fullgrass,
@@ -1802,13 +1757,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-<<<<<<< Updated upstream
-=======
-"blY" = (
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood)
->>>>>>> Stashed changes
 "bma" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -11020,7 +10968,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
 	icon_state = "tealwhrusty_chess2"
-<<<<<<< Updated upstream
 	},
 /area/f13/brotherhood)
 "hRv" = (
@@ -11031,18 +10978,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-=======
-	},
-/area/f13/brotherhood)
-"hRv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
->>>>>>> Stashed changes
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood)
 "hSI" = (
@@ -11079,20 +11014,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/f13/brotherhood)
-<<<<<<< Updated upstream
-=======
-"hUK" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 5;
-	height = 7;
-	id = "supply_home";
-	name = "Cargo Bay";
-	width = 12
-	},
-/turf/open/floor/pod/light,
-/area/f13/brotherhood)
->>>>>>> Stashed changes
 "hUY" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -11212,7 +11133,6 @@
 /obj/structure/flora/junglebush/b,
 /obj/structure/flora/ausbushes/ppflowers{
 	pixel_x = -6
-<<<<<<< Updated upstream
 	},
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/window/reinforced{
@@ -11224,19 +11144,6 @@
 	dir = 1;
 	layer = 3
 	},
-=======
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
->>>>>>> Stashed changes
 /turf/open/water,
 /area/f13/brotherhood)
 "idJ" = (
@@ -11507,11 +11414,7 @@
 	},
 /area/f13/followers)
 "iqA" = (
-<<<<<<< Updated upstream
 /turf/open/floor/pod/dark,
-=======
-/turf/open/floor/pod/light,
->>>>>>> Stashed changes
 /area/f13/brotherhood)
 "irs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16223,7 +16126,6 @@
 	},
 /area/f13/bunker)
 "omy" = (
-<<<<<<< Updated upstream
 /obj/docking_port/stationary{
 	dir = 8;
 	dwidth = 5;
@@ -16233,9 +16135,6 @@
 	width = 12
 	},
 /turf/open/floor/pod/light,
-=======
-/turf/open/floor/pod/dark,
->>>>>>> Stashed changes
 /area/f13/brotherhood)
 "omE" = (
 /obj/structure/ore_box,
@@ -16697,17 +16596,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "4-8"
-<<<<<<< Updated upstream
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-=======
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
->>>>>>> Stashed changes
 /area/f13/brotherhood)
 "oJK" = (
 /obj/structure/railing{
@@ -19093,19 +18985,11 @@
 /obj/structure/curtain{
 	color = "#5c131b";
 	pixel_y = -32
-<<<<<<< Updated upstream
 	},
 /obj/item/kirbyplants/photosynthetic,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "casino"
 	},
-=======
-	},
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
->>>>>>> Stashed changes
 /area/f13/brotherhood)
 "rAu" = (
 /obj/machinery/autolathe,
@@ -19902,7 +19786,6 @@
 	},
 /obj/structure/chair/bench{
 	pixel_y = 15
-<<<<<<< Updated upstream
 	},
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood)
@@ -19911,16 +19794,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-=======
-	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood)
-"stH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
->>>>>>> Stashed changes
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "stX" = (
@@ -22356,17 +22229,10 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-<<<<<<< Updated upstream
 	},
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
 	},
-=======
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
->>>>>>> Stashed changes
 /area/f13/brotherhood)
 "vwJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23512,7 +23378,6 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
-<<<<<<< Updated upstream
 	},
 /area/f13/brotherhood)
 "wNJ" = (
@@ -23521,9 +23386,6 @@
 	dir = 1
 	},
 /turf/closed/wall/r_wall/f13/vault,
-=======
-	},
->>>>>>> Stashed changes
 /area/f13/brotherhood)
 "wNV" = (
 /obj/structure/rack/shelf_metal,
@@ -24620,13 +24482,8 @@
 	},
 /area/f13/brotherhood)
 "yfD" = (
-<<<<<<< Updated upstream
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-=======
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
->>>>>>> Stashed changes
 /turf/open/floor/plasteel/darkpurple,
 /area/f13/brotherhood)
 "yfV" = (
@@ -73289,7 +73146,6 @@ ryF
 ryF
 oVq
 uQM
-<<<<<<< Updated upstream
 aQB
 aQB
 aQB
@@ -73302,20 +73158,6 @@ aQB
 aQB
 aQB
 aQB
-=======
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
->>>>>>> Stashed changes
 oVq
 icO
 fFB
@@ -73561,7 +73403,6 @@ ryF
 ryF
 oVq
 uQM
-<<<<<<< Updated upstream
 iqA
 iqA
 iqA
@@ -73574,20 +73415,6 @@ iqA
 iqA
 iqA
 iqA
-=======
-omy
-omy
-omy
-omy
-omy
-omy
-omy
-omy
-omy
-omy
-omy
-omy
->>>>>>> Stashed changes
 oVq
 cTh
 onW
@@ -73833,7 +73660,6 @@ lBb
 ryF
 oVq
 uQM
-<<<<<<< Updated upstream
 aQB
 aQB
 aQB
@@ -73846,20 +73672,6 @@ aQB
 aQB
 aQB
 aQB
-=======
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
->>>>>>> Stashed changes
 oVq
 sXj
 ajc
@@ -74105,7 +73917,6 @@ lBb
 ryF
 oVq
 uQM
-<<<<<<< Updated upstream
 aQB
 aQB
 aQB
@@ -74118,20 +73929,6 @@ aQB
 aQB
 aQB
 aQB
-=======
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
->>>>>>> Stashed changes
 oVq
 saZ
 ajc
@@ -74377,7 +74174,6 @@ lBb
 ryF
 oVq
 uQM
-<<<<<<< Updated upstream
 aQB
 aQB
 aQB
@@ -74390,20 +74186,6 @@ aQB
 aQB
 aQB
 aQB
-=======
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
->>>>>>> Stashed changes
 oVq
 tWa
 ajc
@@ -74649,7 +74431,6 @@ ryF
 ryF
 oVq
 uQM
-<<<<<<< Updated upstream
 iqA
 iqA
 iqA
@@ -74662,20 +74443,6 @@ iqA
 iqA
 iqA
 iqA
-=======
-omy
-omy
-omy
-omy
-omy
-omy
-omy
-omy
-omy
-omy
-omy
-omy
->>>>>>> Stashed changes
 oVq
 bhS
 ajc
@@ -74921,7 +74688,6 @@ ryF
 ryF
 oVq
 uQM
-<<<<<<< Updated upstream
 aQB
 aQB
 aQB
@@ -74934,20 +74700,6 @@ aQB
 aQB
 aQB
 aQB
-=======
-iqA
-iqA
-iqA
-iqA
-iqA
-iqA
-hUK
-iqA
-iqA
-iqA
-iqA
-iqA
->>>>>>> Stashed changes
 oVq
 wwI
 ajc
@@ -75461,11 +75213,7 @@ pAo
 pAo
 pAo
 xPK
-<<<<<<< Updated upstream
 wNJ
-=======
-aQB
->>>>>>> Stashed changes
 oVq
 onW
 onW
@@ -75717,19 +75465,11 @@ onW
 pvA
 pvA
 onW
-<<<<<<< Updated upstream
 svq
 pvA
 onW
 onW
 svq
-=======
-blY
-pvA
-onW
-onW
-blY
->>>>>>> Stashed changes
 oVq
 onW
 onW
@@ -75979,22 +75719,14 @@ oVq
 equ
 onW
 onW
-<<<<<<< Updated upstream
 svq
-=======
-blY
->>>>>>> Stashed changes
 nfe
 onW
 nnk
 pvA
 onW
 onW
-<<<<<<< Updated upstream
 svq
-=======
-blY
->>>>>>> Stashed changes
 oVq
 onW
 qQK
@@ -76244,22 +75976,14 @@ oVq
 pmx
 onW
 onW
-<<<<<<< Updated upstream
 acU
-=======
->>>>>>> Stashed changes
 onW
 onW
 onW
 onW
 onW
 onW
-<<<<<<< Updated upstream
 svq
-=======
-onW
-blY
->>>>>>> Stashed changes
 oVq
 onW
 ljv
@@ -87543,20 +87267,12 @@ aak
 aak
 aae
 aae
-<<<<<<< Updated upstream
-=======
-aae
-aae
->>>>>>> Stashed changes
 aae
 aae
 aae
 aae
-<<<<<<< Updated upstream
 aae
 aae
-=======
->>>>>>> Stashed changes
 ryF
 jUU
 jUU

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -20575,12 +20575,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building/mall)
-"bAd" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood)
 "bAe" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt,
@@ -24134,10 +24128,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/museum)
-"cOc" = (
-/obj/structure/railing/corner,
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood)
 "cOs" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -30878,15 +30868,8 @@
 	},
 /area/f13/building/massfusion)
 "hdm" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "white"
-	},
+/obj/machinery/door/unpowered/secure_bos,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "hee" = (
 /obj/structure/punching_bag,
@@ -38649,13 +38632,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/massfusion)
 "lVW" = (
-/obj/structure/flora/rock/pile/largejungle{
-	icon_state = "bush3"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/transparent/openspace,
 /area/f13/wasteland/valley)
 "lWe" = (
 /obj/item/chair,
@@ -46176,12 +46153,6 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
-"qJb" = (
-/obj/structure/railing{
-	layer = 4.1
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood)
 "qJm" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -49319,13 +49290,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
-"sFw" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood)
 "sFz" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/drinkingglasses,
@@ -52340,11 +52304,6 @@
 	icon_state = "horizontalbottombordertop2"
 	},
 /area/f13/wasteland/west)
-"uxq" = (
-/obj/structure/barricade/wooden,
-/obj/structure/timeddoor/onetwozerominutes,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "uxE" = (
 /obj/structure/rack,
 /obj/item/clothing/under/suit/black,
@@ -55722,16 +55681,6 @@
 /obj/item/storage/belt,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
-"wAK" = (
-/obj/structure/railing{
-	layer = 4.1
-	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/brotherhood)
 "wBe" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -56700,9 +56649,6 @@
 	},
 /area/f13/wasteland/bighorn)
 "xdC" = (
-/obj/structure/railing{
-	dir = 1
-	},
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
@@ -57037,14 +56983,6 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/village)
-"xqw" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "white"
-	},
-/area/f13/brotherhood)
 "xqx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -90650,7 +90588,7 @@ ksO
 aae
 aae
 aaa
-uxq
+abV
 aaa
 aaa
 aaa
@@ -114259,8 +114197,8 @@ aae
 aae
 rcg
 urG
-dvS
-hdm
+aGi
+urG
 rcg
 cBt
 sTq
@@ -114516,7 +114454,7 @@ aae
 aae
 rcg
 aGi
-xqw
+aGi
 aGi
 buS
 qxy
@@ -116829,9 +116767,9 @@ uSA
 oMJ
 omg
 omg
-cOc
-bAd
-bAd
+htR
+htR
+htR
 bKB
 rcg
 bEB
@@ -117086,9 +117024,9 @@ uSA
 vpy
 rcg
 rcg
-wAK
-dvS
-dvS
+sDb
+htR
+htR
 xdC
 rcg
 lDN
@@ -117343,10 +117281,10 @@ uSA
 nUE
 rcg
 rcg
-qJb
-oQI
-oQI
-sFw
+htR
+htR
+htR
+iOv
 rcg
 pgV
 pgV
@@ -118114,7 +118052,7 @@ rcg
 rcg
 rcg
 rcg
-rcg
+hdm
 rcg
 rcg
 rcg
@@ -118133,7 +118071,7 @@ jPh
 bvG
 mQj
 lVW
-jqU
+lVW
 jVJ
 jVJ
 sTF
@@ -118390,7 +118328,7 @@ gZC
 gZC
 bOm
 fjD
-nfr
+iEy
 jVJ
 jVJ
 sTF


### PR DESCRIPTION
## About The Pull Request

The following PR reorganizes the Brotherhood of Steel base to something more interconnected and easy to navigate while adding flora and fauna throughout the Bunker to give it a sense of livelihood and aesthetics. The PR does not touch the upper mountain z level save for the staircases that lead there. 

The Bunker was not made from scratch but rather a "best hits" volume of previous Bunkers so credits to Naia and co for their bunker and to the user who made the changes to the Wasteland (Rigbe's server) Bunker and the other changes. Other than that, if you want credits then just @ me and I'll be sure to add them in.

(For those looking at the Bunker on post date, the Bunker NEEDS polish, it is not ready. There might be name issues, missing items, etc etc. This needs extensive in game testing.)

## Why It's Good For The Game

The bunker is good because it allows a LOT of interconnectivity within the departments, making movement a breeze. For example, the prisoner bay is right by chemistry & surgery.  The purely "straight" hallways have been changed, allowing divots and even plants to litter the halls as to make things feel different. 

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog

:cl:
tweak: BoS Bunker as a whole
add: Interconnectivity with departments
/:cl:
