### PR TITLE
FEV quickfix, FEV-1 round removal removal.

### DIFF
--- a/code/datums/diseases/f13_fev.dm
+++ b/code/datums/diseases/f13_fev.dm
@@ -1,88 +1,5 @@
 /* FEV diseases */
 // Main code
-/datum/disease/transformation/mutant
-	name = "Forced Evolutionary Virus"
-	cure_text = "mutadone."
-	cures = list(/datum/reagent/medicine/mutadone)
-	cure_chance = 90 // Yeah.
-	stage_prob = 10
-	agent = "FEV-I toxin strain" // The unstable one.
-	desc = "A megavirus, with a protein sheath reinforced by ionized hydrogen. This virus is capable of mutating the affected into something horrifying..."
-	severity = DISEASE_SEVERITY_BIOHAZARD
-	visibility_flags = NONE
-	stage1 = list()
-	stage2 = list()
-	stage3 = list()
-	stage4 = list()
-	stage5 = list("<span class='danger'>You don't feel like yourself anymore!</span>")
-	viable_mobtypes = list(/mob/living/carbon/human)
-	new_form = /mob/living/simple_animal/hostile/centaur
-	var/list/possible_forms = list(\
-		/mob/living/simple_animal/hostile/centaur/strong = 4,
-		/mob/living/simple_animal/hostile/abomination/weak = 3,
-		/mob/living/simple_animal/hostile/ghoul/glowing/strong = 2,
-		)
-
-/datum/disease/transformation/mutant/do_disease_transformation(mob/living/affected_mob)
-	new_form = pickweight(possible_forms)
-	if(!ispath(new_form, /mob/living/carbon)) // If you've become simple_mob - you can't go and be all friendly to those around you!
-		to_chat(affected_mob, "<big><span class='warning'><b>You've become something entirely different! You are being controlled only by your hunger and desire to kill!</b></span></big>")
-	. = ..()
-
-// FEV - I
-/datum/disease/transformation/mutant/unstable/stage_act()
-	..()
-
-	affected_mob.adjustCloneLoss(-4,0) // Don't die while you are mutating.
-	switch(stage)
-		if(2)
-			if (prob(8))
-				to_chat(affected_mob, "<span class='danger'>You feel weird...</span>")
-		if(3)
-			if (prob(12))
-				to_chat(affected_mob, "<span class='danger'>Your skin twitches...</span>")
-				affected_mob.Jitter(3)
-				ADD_TRAIT(affected_mob, TRAIT_FEV, "FEV-I Exposure") //So you can dose FEV, and then take mutadone. Still deadly and dangerous
-		if(4)
-			if (prob(20))
-				to_chat(affected_mob, "<span class='danger'>The pain is unbearable!</span>")
-				affected_mob.emote("cry")
-			if (prob(15))
-				to_chat(affected_mob, "<span class='danger'>Your skin begins to shift, hurting like hell!</span>")
-				affected_mob.emote("scream")
-				affected_mob.Jitter(4)
-			if (prob(6))
-				to_chat(affected_mob, "<span class='danger'>Your body shuts down for a moment!</span>")
-				affected_mob.Unconscious(10)
-
-// FEV - II
-/datum/disease/supermutant
-	agent = "FEV-II toxin strain" // The unstable one.
-	desc = "A megavirus, with a protein sheath reinforced by ionized hydrogen. This variant has been mutated by radiation and will turn the affected person into something less horrifying."
-
-/datum/disease/transformation/mutant/super/stage_act()
-	..()
-
-	switch(stage)
-		if(2)
-			if (prob(8))
-				to_chat(affected_mob, "<span class='danger'>You feel weird...</span>")
-		if(3)
-			if (prob(12))
-				to_chat(affected_mob, "<span class='danger'>Your skin twitches...</span>")
-				affected_mob.Jitter(3)
-		if(4)
-			if (prob(20))
-				to_chat(affected_mob, "<span class='danger'>The pain is unbearable!</span>")
-				affected_mob.emote("scream")
-			if (prob(15))
-				to_chat(affected_mob, "<span class='warning'>Your skin begins to shift, it hurts, but only for a moment..?</span>")
-				affected_mob.emote("cry")
-			if (prob(5))
-				to_chat(affected_mob, "<span class='reallybig hypnophrase'>Simple! Efficient! Glorious!</span>")
-				var/datum/component/mood/mood = affected_mob.GetComponent(/datum/component/mood)
-				mood.setSanity(SANITY_INSANE) // You're happy, aren't you?
-				ADD_TRAIT(affected_mob, TRAIT_FEVII, "FEV-II Exposure")
 
 // FEV - Curling 13
 /datum/disease/curling_thirteen
@@ -173,3 +90,94 @@
 			if(prob(10))
 				affected_mob.adjustToxLoss(5)
 	return
+
+
+/datum/disease/fev1 //You die from mutations.
+	form = "Forced Evolutionary Virus"
+	name = "FEV-I Toxin Strain"
+	max_stages = 4
+	cures = list(/datum/reagent/medicine/mutadone)
+	cure_text = "Mutadone."
+	cure_chance = 40 // Yeah.
+	stage_prob = 30
+	agent = "DNA"
+	desc = "A megavirus, with a protein sheath reinforced by ionized hydrogen. This virus is capable of mutating the affected into something horrifying..."
+	viable_mobtypes = list(/mob/living/carbon/human)
+	severity = DISEASE_SEVERITY_BIOHAZARD
+	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
+	bypasses_immunity = FALSE // This can be cured!
+	var/FEV1trait = FALSE
+
+/datum/disease/fev1/stage_act()
+	..()
+	affected_mob.adjustCloneLoss(-4,0) // Don't die while you are mutating.
+	switch(stage)
+		if(2)
+			if (prob(8))
+				to_chat(affected_mob, "<span class='danger'>You feel weird...</span>")
+				affected_mob.easy_randmut(NEGATIVE+MINOR_NEGATIVE)
+		if(3)
+			if (prob(100))
+				if(!FEV1trait)
+					to_chat(affected_mob, "<span class='danger'>Your skin twitches and swells...</span>")
+					affected_mob.Jitter(3)
+					ADD_TRAIT(affected_mob, TRAIT_FEV, "FEV-I Exposure") //So you can dose FEV, and then take mutadone. Still deadly and dangerous
+					affected_mob.easy_randmut(NEGATIVE+MINOR_NEGATIVE)
+					FEV1trait = TRUE
+				if(prob(2))
+					affected_mob.easy_randmut(NEGATIVE+MINOR_NEGATIVE)
+		if(4)
+			if (prob(20))
+				to_chat(affected_mob, "<span class='danger'>The pain is unbearable!</span>")
+				affected_mob.emote("cry")
+			if (prob(15))
+				to_chat(affected_mob, "<span class='danger'>Your skin begins to shift, hurting like hell!</span>")
+				affected_mob.emote("scream")
+				affected_mob.Jitter(4)
+				affected_mob.easy_randmut(NEGATIVE+NEGATIVE)
+			if (prob(6))
+				to_chat(affected_mob, "<span class='danger'>Your body shuts down for a moment!</span>")
+				affected_mob.Unconscious(10)
+
+
+/datum/disease/fev2 //You die from mutations.
+	form = "Forced Evolutionary Virus"
+	name = "FEV-II Stable Strain"
+	max_stages = 4
+	cures = list(/datum/reagent/medicine/mutadone, /datum/reagent/medicine/haloperidol)
+	cure_text = "Mutadone."
+	cure_chance = 5 // Nonlethal.
+	stage_prob = 30
+	agent = "DNA"
+	desc = "A megavirus, with a protein sheath reinforced by ionized hydrogen, which has been however, affected by radiation. This will mutate the host into something less... Horrifying."
+	viable_mobtypes = list(/mob/living/carbon/human)
+	severity = DISEASE_SEVERITY_BIOHAZARD
+	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
+	bypasses_immunity = FALSE // This can be cured!
+	var/FEV2trait = FALSE
+
+/datum/disease/fev2/stage_act()
+	..()
+	affected_mob.adjustCloneLoss(-4,0) // Don't die while you are mutating.
+	switch(stage)
+		if(2)
+			if (prob(8))
+				to_chat(affected_mob, "<span class='danger'>You feel weird...</span>")
+				affected_mob.easy_randmut(NEGATIVE+MINOR_NEGATIVE)
+				affected_mob.emote("cough")
+		if(3)
+			if(prob(2))
+				to_chat(affected_mob, "<span class='danger'>Your skin hurts, and your insides burn!</span>")
+				affected_mob.adjustCloneLoss(2,0)
+				affected_mob.emote("cough")
+		if(4)
+			if(!FEV2trait)
+				to_chat(affected_mob, "<span class='reallybig hypnophrase'>Simple! Efficient! Glorious!</span>")
+				var/datum/component/mood/mood = affected_mob.GetComponent(/datum/component/mood)
+				mood.setSanity(SANITY_INSANE) // You're happy, aren't you?
+				ADD_TRAIT(affected_mob, TRAIT_FEVII, "FEV-II Exposure")
+				FEV2trait = TRUE //Stops spam
+				affected_mob.emote("screams")
+			to_chat(affected_mob, "<span class='danger'>You feel the lingering effects of the virus in your blood...</span>") //Warning that you're still able to infect others via blood to blood transmission
+
+

--- a/code/modules/food_and_drinks/recipes/processor_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/processor_recipes.dm
@@ -12,6 +12,10 @@
 	input = /obj/item/reagent_containers/food/snacks/meat/rawcutlet
 	output = /obj/item/reagent_containers/food/snacks/meat/rawbacon
 
+/datum/food_processor_process/meatwheat
+	input = /obj/item/reagent_containers/food/snacks/grown/meatwheat
+	output = /obj/item/reagent_containers/food/snacks/meat/slab/meatwheat
+
 /datum/food_processor_process/potatowedges
 	input = /obj/item/reagent_containers/food/snacks/grown/potato/wedges
 	output = /obj/item/reagent_containers/food/snacks/fries

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -48,7 +48,7 @@
 	description = "You aren't meant to see this..?"
 	color = "#00FF00"
 	toxpwr = 0
-	overdose_threshold = 18 // FEV Fixed.
+	overdose_threshold = 1 // FEV Fixed.
 	taste_description = "horrific agony"
 	taste_mult = 0.9
 	var/datum/disease/fev_disease = null
@@ -61,7 +61,7 @@
 /datum/reagent/toxin/FEV_solution/one
 	name = "Unstable FEV solution"
 	description = "An incredibly lethal strain of the Forced Evolutionary Virus. Consume at your own risk."
-	fev_disease = /datum/disease/transformation/mutant/unstable
+	fev_disease = /datum/disease/fev1
 
 /datum/reagent/toxin/FEV_solution/one/reaction_mob(mob/living/carbon/M, method=TOUCH, reac_volume)
 	if(!..())
@@ -83,21 +83,13 @@
 /datum/reagent/toxin/FEV_solution/two
 	name = "FEV-II solution"
 	description = "A version of FEV that has been modified by radiation. A biological dead-end, harmless if the subject is not exposed to radiation."
-	fev_disease = /datum/disease/supermutant
+	fev_disease = /datum/disease/fev2
 
 /datum/reagent/toxin/FEV_solution/two/overdose_process(mob/living/carbon/C)
-	if(C.radiation < RAD_MOB_SAFE)
-		C.reagents.remove_reagent(src.type,10) // Clean up
-		return ..() // Infect with disease
-	else // You fucked up
-		if(prob(5))
-			to_chat(C, "<span class='danger'>IT BURNS!</span>")
-			C.emote("scream")
-			C.adjustFireLoss(10,0)
-		C.adjustFireLoss(5,0)
-		C.apply_effect(10,EFFECT_IRRADIATE,0) // Now the only thing you are turning into is a ghoul
-		C.Jitter(2)
-	return
+	C.adjustFireLoss(5,0)
+	C.apply_effect(1,EFFECT_IRRADIATE,0) //FEV-II is radioactive.
+	C.Jitter(2)
+	return ..()
 
 //FEV - Curling 13: The murderous type
 /datum/reagent/toxin/FEV_solution/curling


### PR DESCRIPTION
:cl:
Fix: FEV diseases (x2)
Tweak: Removes FEV RR, changes how the diseases work.
Add: Meatwheat -> Meatwheat clumps in food processor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
