### PR TITLE
Fully Fixes FEV Sizechanges

### DIFF
--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -26,7 +26,8 @@
 	quirk_holder.become_mega_nearsighted(ROUNDSTART_TRAIT) //Custom proc to make essentially welder-blindness.
 	mob_tar.maxHealth += 30 //These guys are tanky. Almost blind, and slower.
 	mob_tar.health += 30
-	mob_tar.dna.features["body_size"] = (mob_tar.dna.features["body_size"]+0.1)
+	mob_tar.resize += 0.15
+	mob_tar.update_transform()
 	to_chat(mob_tar, "<span class='notice'>You feel far stronger, and a tad dumber...</span>")
 
 /datum/quirk/fev/remove()
@@ -36,7 +37,8 @@
 	mob_tar.health -= 30
 	mob_tar.dna.species.punchdamagelow -= 6
 	mob_tar.dna.species.punchdamagehigh -= 8 
-	mob_tar.dna.features["body_size"] = (mob_tar.dna.features["body_size"]-0.1)
+	mob_tar.resize -= 0.15
+	mob_tar.update_transform()
 
 /datum/quirk/fevII //FRANK FUCKING HORRIGAAAN
 	name = "FEV-II Exposure"
@@ -54,7 +56,8 @@
 	mob_tar.dna.species.punchdamagehigh += 20  //Your head is exploding.
 	mob_tar.maxHealth += 70 //Mutie rage.
 	mob_tar.health += 70
-	mob_tar.dna.features["body_size"] = (mob_tar.dna.features["body_size"]+0.2)
+	mob_tar.resize += 0.25
+	mob_tar.update_transform()
 	to_chat(mob_tar, "<span class='danger'>You feel extremely strong!</span>")
 
 /datum/quirk/fevII/remove()
@@ -63,7 +66,8 @@
 	mob_tar.dna.species.punchdamagehigh -= 20 //Prevents stacking
 	mob_tar.maxHealth -= 70 //Mutie rage.
 	mob_tar.health -= 70
-	mob_tar.dna.features["body_size"] = (mob_tar.dna.features["body_size"]-0.2)
+	mob_tar.resize -= 0.25
+	mob_tar.update_transform()
 
 /datum/quirk/snob
 	name = "Snob"


### PR DESCRIPTION
:cl:
Fix: Uses mob.resize versus the DNA body_size function (similar to the gigantism trait) and designs it around adding to the current mob.resize
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
