### PR TITLE
fixes SPA

### DIFF
--- a/code/modules/clothing/suits/heavy_armor.dm
+++ b/code/modules/clothing/suits/heavy_armor.dm
@@ -81,6 +81,7 @@
 	It isn't meant to be used, it just dictates procs and all that stuff to the subtypes, such as t45b and so on. \
 	Now begone, report this to coders. NOW!"
 	slowdown = 0.6
+	var/spaequipped = FALSE
 
 /obj/item/clothing/suit/armored/heavy/salvaged_pa/equipped(mob/user, slot)
 	..()
@@ -89,10 +90,12 @@
 /obj/item/clothing/suit/armored/heavy/salvaged_pa/proc/assign_traits(mob/user)
 	ADD_TRAIT(user, TRAIT_PUSHIMMUNE, "PA_push_immunity") //SPA makes you really hard to push.
 	if(isliving(user))
+		if(!spaequipped)
 		to_chat(user, "<span class='notice'>You feel safer surrounded by steel.</span>")
 		var/mob/living/carbon/human/H = user
 		H.maxHealth += 25
 		H.health += 25
+		spaequipped = TRUE
 
 /obj/item/clothing/suit/armored/heavy/salvaged_pa/dropped(mob/user)
 	..()
@@ -101,10 +104,12 @@
 /obj/item/clothing/suit/armored/heavy/salvaged_pa/proc/remove_traits(mob/user)
 	REMOVE_TRAIT(user, TRAIT_PUSHIMMUNE, "PA_push_immunity")
 	if(isliving(user))
-		to_chat(user, "<span class='notice'>You feel less safe, and vulnerable!</span>")
-		var/mob/living/carbon/human/H = user
-		H.maxHealth -= 25
-		H.health -= 25
+		if(spaequipped)
+			to_chat(user, "<span class='notice'>You feel less safe, and vulnerable!</span>")
+			var/mob/living/carbon/human/H = user
+			H.maxHealth -= 25
+			H.health -= 25
+			spaequipped = FALSE
 
 // T-45B
 /obj/item/clothing/suit/armored/heavy/salvaged_pa/t45b


### PR DESCRIPTION
:cl:
fix: Speedruns SPA suicide
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
