### PR TITLE
BoS Civilian Door Fix

### DIFF
--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -280,7 +280,7 @@
 			playsound(src,'sound/machines/door_close.ogg',40,1)
 			flick("secure_bos_closing", src)
 
-/obj/machinery/door/unpowered/secure_bosciv
+/obj/machinery/door/unpowered/secure_bos/civ
 	name = "steel security door"
 	desc = "Hard steel makes a statement. The statement in this case is stay out."
 	icon_state = "secure_bos"


### PR DESCRIPTION
:cl:
fix: Jasminecode gone, chadcode in. Fixes BoS Civilian Doors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
