### PR TITLE
Revert "Replaces the 40mm GL among the Prime Decanus loadouts with a Rock-It Launcher and several High-Explosive nades."

### DIFF
--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -505,14 +505,13 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 
 /datum/outfit/loadout/decprimboom
 	name = "Loud Prime Decanus"
-	suit_store = null
+	suit_store = /obj/item/gun/ballistic/revolver/grenadelauncher
 	backpack_contents = list(
-		/obj/item/grenade/syndieminibomb/concussion = 5,
+		/obj/item/ammo_box/a40mm = 2,
 		/obj/item/gun/ballistic/revolver/m29 = 1,
 		/obj/item/ammo_box/m44 = 3,
 		/obj/item/grenade/f13/frag = 2,
 		/obj/item/grenade/homemade/coffeepotbomb = 1,
-		/obj/item/rockitlauncher_pack = 1,
 		)
 
 


### PR DESCRIPTION
Reverts JasmineRickards/Wasteland-After-Dark#4