### PR TITLE
series of legion leader armor tweaks, some melee tweaks, buff vet ranger armor (kind of), bullets

### DIFF
--- a/code/modules/clothing/head/f13factionhead.dm
+++ b/code/modules/clothing/head/f13factionhead.dm
@@ -723,7 +723,7 @@
 	desc = "An old combat helmet, out of use around the time of the war."
 	icon_state = "ranger"
 	item_state = "ranger"
-	armor = list("melee" = 40, "bullet" = 50, "laser" = 40, "energy" = 15, "bomb" = 55, "bio" = 60, "rad" = 60, "fire" = 90, "acid" = 20, "wound" = 55)
+	armor = list("melee" = 35, "bullet" = 55, "laser" = 45, "energy" = 35, "bomb" = 55, "bio" = 60, "rad" = 60, "fire" = 90, "acid" = 20, "wound" = 55)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR|HIDEFACE|HIDESNOUT
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	resistance_flags = LAVA_PROOF | FIRE_PROOF

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -204,7 +204,7 @@
 
 /obj/item/clothing/suit/armor/f13/legion/recruit
 	name = "legion recruit armor"
-	desc = "Well, it's better than nothing."
+	desc = "Football gear that has been reinforced with steel plates and treated leather. Better than nothing."
 	icon_state = "legion_recruit"
 	item_state = "legion_recruit"
 	armor = list("melee" = 33, "bullet" = 25, "laser" = 5, "energy" = 10, "bomb" = 20, "bio" = 20, "rad" = 20, "fire" = 25, "acid" = 0, "wound" = 10)
@@ -212,8 +212,8 @@
 
 /obj/item/clothing/suit/armor/f13/legion/recruit/decan
 	name = "legion recruit armor"
-	desc = "Recruit decanii receive slightly better protection than regular recruits. Slightly."
-	armor = list("melee" = 40, "bullet" = 30, "laser" = 5, "energy" = 10, "bomb" = 20, "bio" = 20, "rad" = 20, "fire" = 25, "acid" = 0, "wound" = 10)
+	desc = "A recruit legionary's armor worn over a cheap low-key kevlar vest to catch shrapnel."
+	armor = list("melee" = 40, "bullet" = 30, "laser" = 5, "energy" = 10, "bomb" = 20, "bio" = 20, "rad" = 20, "fire" = 25, "acid" = 0, "wound" = 20)
 
 /obj/item/clothing/suit/armor/f13/legion/prime
 	name = "legion prime armor"
@@ -224,8 +224,8 @@
 
 /obj/item/clothing/suit/armor/f13/legion/prime/decan
 	name = "legion prime decanus armor"
-	desc = "Legion prime decanus armor-an extra reinforced baseball uniform."
-	armor = list("melee" = 45, "bullet" = 35, "laser" = 10, "energy" = 10, "bomb" = 20, "bio" = 20, "rad" = 20, "fire" = 25, "acid" = 0, "wound" = 10)
+	desc = "A prime legionary's armor worn over a light kevlar vest to catch shrapnel and absorb impacts."
+	armor = list("melee" = 45, "bullet" = 35, "laser" = 10, "energy" = 10, "bomb" = 20, "bio" = 20, "rad" = 20, "fire" = 25, "acid" = 0, "wound" = 25)
 
 /obj/item/clothing/suit/armor/f13/legion/orator
 	name = "Legion Orator armor"
@@ -253,17 +253,17 @@
 
 /obj/item/clothing/suit/armor/f13/legion/heavy
 	name = "legion veteran decan armor"
-	desc = "A Legion veterans armor reinforced with a patched bulletproof vest, the wearer has the markings of a Decanus."
+	desc = "A set of Veteran Legionary armor with ceramic plating leftover from combat armor, worn over a high-quality kevlar vest. It's much heavier than typical Legion armor."
 	icon = 'icons/fallout/clothing/armored_heavy.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/armor_heavy.dmi'
 	icon_state = "legion_heavy"
 	item_state = "legion_heavy"
-	armor = list("melee" = 60, "bullet" = 46, "laser" = 25, "energy" = 15, "bomb" = 25, "bio" = 50, "rad" = 20, "fire" = 70, "acid" = 0, "wound" = 20)
+	armor = list("melee" = 60, "bullet" = 46, "laser" = 25, "energy" = 15, "bomb" = 25, "bio" = 50, "rad" = 20, "fire" = 70, "acid" = 0, "wound" = 30)
 	slowdown = 0.1
 	salvage_loot = list(/obj/item/stack/crafting/armor_plate = 5)
 
 /obj/item/clothing/suit/armor/f13/legion/vet/explorer
-	name = "legion scout armor"
+	name = "legion explorer armor"
 	desc = "Armor based on layered strips of laminated linen and leather, the technique giving it surprising resilience for low weight."
 	icon = 'icons/fallout/clothing/armored_light.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/armor_light.dmi'
@@ -275,18 +275,18 @@
 /obj/item/clothing/suit/armor/f13/legion/vet/vexil
 	name = "legion vexillarius armor"
 	icon = 'icons/fallout/clothing/armored_medium.dmi'
-	desc = " Worn by Vexillarius, this armor has been reinforced with circular metal plates on the chest and a back mounted pole for the flag of the Bull, making the wearer easy to see at a distance."
+	desc = "A set of Veteran Legionary armor with flag-bearer insignia, worn over a high-quality kevlar vest."
 	icon_state = "legion_vex"
 	item_state = "legion_vex"
-	armor = list("melee" = 57, "bullet" = 42, "laser" = 42, "energy" = 20, "bomb" = 30, "bio" = 30, "rad" = 30, "fire" = 30, "acid" = 0, "wound" = 10)
+	armor = list("melee" = 57, "bullet" = 42, "laser" = 42, "energy" = 20, "bomb" = 30, "bio" = 30, "rad" = 30, "fire" = 30, "acid" = 0, "wound" = 30) //Must compete with HT so we will give it wound armor equivalent to the veteran decanus'
 	slowdown = 0.05
 
 /obj/item/clothing/suit/armor/f13/legion/venator
-	name = "legion explorer armor"
-	desc = "Explorer armor reinforced with metal plates and chainmail."
+	name = "legion venator armor"
+	desc = "Explorer armor reinforced with kevlar and light chainmail."
 	icon_state = "legion-venator"
 	item_state = "legion-venator"
-	armor = list("melee" = 50, "bullet" = 35, "laser" = 20, "energy" = 20, "bomb" = 20, "bio" = 20, "rad" = 20, "fire" = 25, "acid" = 0, "wound" = 10)
+	armor = list("melee" = 50, "bullet" = 35, "laser" = 20, "energy" = 20, "bomb" = 20, "bio" = 20, "rad" = 20, "fire" = 25, "acid" = 0, "wound" = 15)
 	salvage_loot = list(/obj/item/stack/crafting/armor_plate = 5)
 
 /obj/item/clothing/suit/armor/f13/legion/centurion //good all around
@@ -296,7 +296,7 @@
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/armor_heavy.dmi'
 	icon_state = "legion_centurion"
 	item_state = "legion_centurion"
-	armor = list("melee" = 60, "bullet" = 50, "laser" = 35, "energy" = 25, "bomb" = 45, "bio" = 20, "rad" = 20, "fire" = 45, "acid" = 45, "wound" = 20)
+	armor = list("melee" = 60, "bullet" = 50, "laser" = 35, "energy" = 25, "bomb" = 45, "bio" = 20, "rad" = 20, "fire" = 45, "acid" = 45, "wound" = 30)
 	slowdown = 0.1
 	salvage_loot = list(/obj/item/stack/crafting/armor_plate = 10) // Rest in pieces
 
@@ -307,8 +307,8 @@
 	desc = "A Centurion able to defeat a Brotherhood Paladin gets the honorific title 'Paladin-Slayer', and adds bits of the looted armor to his own."
 	icon_state = "legion_palacent"
 	item_state = "legion_palacent"
-	armor = list("melee" = 55, "bullet" = 45, "laser" = 70, "energy" = 65, "bomb" = 55, "bio" = 20, "rad" = 20, "fire" = 25, "acid" = 0, "wound" = 20)
-	slowdown = 0.3
+	armor = list("melee" = 55, "bullet" = 45, "laser" = 70, "energy" = 65, "bomb" = 55, "bio" = 20, "rad" = 20, "fire" = 25, "acid" = 0, "wound" = 40) //almost SPA
+	slowdown = 0.35
 
 
 /obj/item/clothing/suit/armor/f13/legion/rangercent //speed and bullet resist, sacrifices all else
@@ -329,7 +329,7 @@
 	icon_state = "legion_legate"
 	item_state = "legion_legate"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
-	armor = list("melee" = 60, "bullet" = 60, "laser" = 40, "energy" = 35, "bomb" = 45, "bio" = 60, "rad" = 20, "fire" = 80, "acid" = 0, "wound" = 10)
+	armor = list("melee" = 60, "bullet" = 60, "laser" = 40, "energy" = 35, "bomb" = 45, "bio" = 60, "rad" = 20, "fire" = 80, "acid" = 0, "wound" = 50) //Admin spawn
 	salvage_loot = list(/obj/item/stack/crafting/armor_plate = 15) // Wouldn't it be hilarious if we just tore apart the Legate's armor?
 
 /obj/item/clothing/suit/armor/f13/combat/legion
@@ -605,7 +605,7 @@
 	item_state = "ranger"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
 	slowdown = 0.03
-	armor = list("melee" = 30, "bullet" = 45, "laser" = 35, "energy" = 15, "bomb" = 55, "bio" = 60, "rad" = 60, "fire" = 90, "acid" = 20, "wound" = 35)
+	armor = list("melee" = 25, "bullet" = 55, "laser" = 45, "energy" = 35, "bomb" = 55, "bio" = 60, "rad" = 60, "fire" = 90, "acid" = 20, "wound" = 35) //Somewhat weak to melee but comparatively strong otherwise
 	salvage_loot = list(/obj/item/stack/crafting/armor_plate = 8)
 
 /obj/item/clothing/suit/armor/f13/rangercombat/Initialize()

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -386,13 +386,15 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/mm14
 	name = "14mm FMJ bullet"
-	damage = 32
+	damage = 30
 	wound_bonus = 42
 	bare_wound_bonus = 28
+	armour_penetration = 0.25 //It says AP in code comments yet it had no AP?
 
 /obj/item/projectile/bullet/mm14/contam
 	name = "14mm contaiminated bullet"
-	damage = 18
+	damage = 15
+	armour_penetration = 0.1 
 	var/smoke_radius = 1
 
 /obj/item/projectile/bullet/mm14/contam/Initialize()
@@ -412,8 +414,8 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/mm14/uraniumtipped
 	name = "14mm uranium-tipped bullet"
-	damage = 24
-	armour_penetration = 0.1
+	damage = 20
+	armour_penetration = 0.35
 	irradiate = 80
 
 

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -81,7 +81,7 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 /obj/item/projectile/bullet/a556/uraniumtipped
 	name = "5.56 uranium-tipped bullet"
 	damage = 24
-	armour_penetration = 0.1
+	armour_penetration = 0.25
 	irradiate = 50
 
 /obj/item/projectile/bullet/a556/simple //for simple mobs, separate to allow balancing
@@ -127,9 +127,9 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	armour_penetration = 0.2
 
 /obj/item/projectile/bullet/a762/uraniumtipped
-	name = "7.62 uranium-tipped bullet"
+	name = "7.62 depleted uranium bullet"
 	damage = 30
-	armour_penetration = 0.2
+	armour_penetration = 0.4
 	irradiate = 30
 
 /obj/item/projectile/bullet/a762/microshrapnel
@@ -190,7 +190,7 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	name = "12.7mm uranium-tipped bullet"
 	damage = 50
 	armour_penetration = 1
-	irradiate = 30
+	irradiate = 300
 
 /obj/item/projectile/bullet/a50MG/contam
 	name = "12.7mm contaminated bullet"
@@ -306,7 +306,7 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 //////////////////////////
 
 /obj/item/projectile/bullet/m5mm  //for rifles// one of the only bullets to have integral AP
-	damage = 19
+	damage = 20
 	wound_bonus = 24
 	bare_wound_bonus = 10
 	armour_penetration = 0.45
@@ -321,7 +321,7 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 
 /obj/item/projectile/bullet/m5mm/shock
 	name = "5mm shock bullet"
-	damage = 13.3 //70% of 19
+	damage = 14
 	wound_bonus = 0
 	sharpness = SHARP_NONE
 
@@ -334,7 +334,7 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 //////////////////////////
 
 /obj/item/projectile/bullet/c5mm
-	damage = 19
+	damage = 15
 	armour_penetration = 0.5
 
 

--- a/code/modules/smithing/finished_items.dm
+++ b/code/modules/smithing/finished_items.dm
@@ -221,7 +221,7 @@
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/belt.dmi'
 	layer = MOB_UPPER_LAYER
 	wound_bonus = 20
-	block_chance = 15
+	block_chance = 20
 
 /obj/item/melee/smith/sword/spatha
 	name = "spatha"
@@ -236,9 +236,9 @@
 	item_state = "sabre_smith"
 	overlay_state = "hilt_sabre"
 	block_parry_data = /datum/block_parry_data/smithsaber
-	armour_penetration = 0.2
+	armour_penetration = 0.25
 	force = 24
-	block_chance = 25
+	block_chance = 45
 
 /datum/block_parry_data/smith_generic
 	parry_stamina_cost = 12
@@ -297,12 +297,13 @@
 	force = 24
 	sharpness = SHARP_EDGED
 	wound_bonus = 30
-	block_chance = 20
+	block_chance = 30
 
 /obj/item/melee/smith/machete/gladius
 	name = "gladius"
 	icon_state = "gladius_smith"
 	overlay_state = "hilt_gladius"
+	block_chance = 35
 
 /obj/item/melee/smith/machete/reforged
 	name = "reforged machete"
@@ -318,7 +319,7 @@
 	item_flags = NEEDS_PERMIT | ITEM_CAN_PARRY
 	block_parry_data = /datum/block_parry_data/waki
 	hitsound = 'sound/weapons/rapierhit.ogg'
-	block_chance = 5
+	block_chance = 15
 	wound_bonus = 15
 	bare_wound_bonus = 30
 
@@ -370,7 +371,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/belt.dmi'
 	layer = MOB_UPPER_LAYER
-	block_chance = 30
+	block_chance = 40
 	wound_bonus = 25
 	bare_wound_bonus = 40
 
@@ -387,7 +388,7 @@
 	parry_efficiency_to_counterattack = 100
 	parry_efficiency_considered_successful = 120
 	parry_efficiency_perfect = 120
-	parry_data = list(PARRY_COUNTERATTACK_MELEE_ATTACK_CHAIN = 0.6)
+	parry_data = list(PARRY_COUNTERATTACK_MELEE_ATTACK_CHAIN = 2)
 
 // Heavy axe, 2H focused chopper 27/54. Can be worn on your back.
 /obj/item/melee/smith/twohand/axe
@@ -402,8 +403,10 @@
 	slot_flags = ITEM_SLOT_BACK
 	layer = MOB_UPPER_LAYER
 	block_parry_data = /datum/block_parry_data/smith_generic
-	wound_bonus = 10
-	bare_wound_bonus = 10
+	wound_bonus = 40
+	bare_wound_bonus = 25
+	block_chance = 20
+	armour_penetration = 0.3
 
 /obj/item/melee/smith/twohand/axe/afterattack(atom/A, mob/living/user, proximity)
 	. = ..()
@@ -423,6 +426,10 @@
 	icon_state = "warhoned_smith"
 	icon_prefix = "warhoned_smith"
 	overlay_state = "shaft_warhoned"
+	wound_bonus = 45						//The craftsmanship is simply unrivaled
+	bare_wound_bonus = 30
+	block_chance = 25
+	armour_penetration = 0.5
 
 /obj/item/melee/smith/twohand/axe/warhoned/afterattack(atom/A, mob/living/user, proximity)
 	. = ..()
@@ -488,7 +495,7 @@
 	sharpness = SHARP_POINTY
 	embedding = list("pain_mult" = 2, "embed_chance" = 60, "fall_chance" = 20, "ignore_throwspeed_threshold" = TRUE)
 	force = 15
-	armour_penetration = 0.10
+	armour_penetration = 0.3
 
 // Smaller weaker javelin, easier to store/carry, less effective
 /obj/item/melee/smith/throwingknife
@@ -497,9 +504,9 @@
 	overlay_state = "handle_throwing"
 	item_state = "dagger_smith"
 	embedding = list("pain_mult" = 2, "embed_chance" = 50, "fall_chance" = 20, "ignore_throwspeed_threshold" = TRUE)
-	force = 14
+	force = 12
 	w_class = WEIGHT_CLASS_SMALL
-
+	armour_penetration = 0.15
 
 // TG stuff
 


### PR DESCRIPTION
### NCR Veteran Ranger
Somewhat weaker to melee, but higher tolerance to bullets, lasers, and plasma.

### Recruit Decanus, Prime Decanus, Veteran Decanus, Vexillarius, and Centurion + Explorer-Venator
Gives recruit decanus 20 wound armor from 10, for being a leadership role
Gives prime decanus 25 wound armor from 10, for being a leadership role
Gives veteran decanus 30 wound armor from 10, for being a leadership role
Gives vexillarius 30 wound armor from 10, for being the dedicated heavy hitter and damage sponge (Mirroring HT)
Gives centurion SPA 40 wound armor, because that thing is SPA. No other changes to cent.
Gives venator 15 wound armor from 10, for being a leadership role - but maintaining super light armor.
Explorer armor and venator armor are now aptly named

### Smithed weapons
Makes axes very wounding and gives them armor piercing, since you give up both your hands to use them, and can't carry them on your bag. Makes the legion war honed axe perform a little better than a regular smithed axe to avoid it from falling behind and to incentivize people to trade for them

Buffs block chance of most smithed weapons, because they were useless. Similarly, the katana applies 2 hits on a succesful parry instead of 0.6 hits.

Javelins and throwing knives have a little bit of AP now too, since they had no use otherwise.

### Bullets
Uranium bullets now have a better AP bonus, so now you have a reason to craft them in lieu of their lower damage
5mm does 20 damage instead of 19
Minigun 5mm now does 15 damage instead of 20
14mm now has innate armor piercing capabilities, as it was said to be an AP round in the code comments
.50 cal irradiated ammo now gives you a lot of rads, because it was useless before.

I think this will benefit game balance... Currently it's hard to obtain good melee weapons for PVP because plenty of them lack good armor piercing capabilities, and you're better off ditching them for guns instead. It will also bring legion leaders up to speed a little bit, since their armor is still kind of weak overall as a faction. The NCR armors all have 30-50 wound armor, so I think it is fair. People will also start making uranium bullets now that the trade-off is worth it.
It also does not intrude on the proton axe's niche, since the proton axe can slice through power armor. And unique items like the super sledge still have their headshot knockdown.