### PR TITLE
<Qwikfix> Protectorate goofery

### DIFF
--- a/code/modules/jobs/job_types/bos_civilian.dm
+++ b/code/modules/jobs/job_types/bos_civilian.dm
@@ -113,6 +113,7 @@
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
 		/obj/item/reagent_containers/medspray/synthflesh = 1,
 		/obj/item/storage/firstaid = 1,
+		/obj/item/encryptionkey/headset_bos_civi=1,
 		)
 
 /datum/outfit/job/bos/f13protectoratedoctor/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -153,6 +154,7 @@
 	glasses =		/obj/item/clothing/glasses/sunglasses/big
 	backpack_contents = list(
 		/obj/item/storage/firstaid/regular=1,
+		/obj/item/encryptionkey/headset_bos_civi=1,
 		)
 
 /datum/outfit/job/bos/f13protectoratescribe/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -163,7 +165,7 @@
 	ADD_TRAIT(H, TRAIT_MEDICALGRADUATE, src)
 	ADD_TRAIT(H, TRAIT_CHEMWHIZ, src)
 	ADD_TRAIT(H, TRAIT_RESEARCHER, src)
-//	ADD_TRAIT(H, TRAIT_POOR_AIM, src)
+	//ADD_TRAIT(H, TRAIT_POOR_AIM, src)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/AER9)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/AEP7)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/dks)


### PR DESCRIPTION
:cl:
fix: Protectorate comms x2
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
