### PR TITLE
Fixes Anti-Ghost (ERP-Flashbangs-B-Gone)

### DIFF
--- a/code/modules/fallout/reagents/medicines.dm
+++ b/code/modules/fallout/reagents/medicines.dm
@@ -58,7 +58,7 @@
 		M.AdjustKnockdown(-2*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.adjustOxyLoss(-5*REAGENTS_EFFECT_MULTIPLIER,	0)
 		M.adjustStaminaLoss(-2*REAGENTS_EFFECT_MULTIPLIER)//This will probably be horribly unbalanced because of multipliers, but we will see.
-		M.heal_bodypart_damage(1.5,1.5, only_organic = FALSE, only_robotic = TRUE)
+		M.heal_bodypart_damage(3,3, only_organic = FALSE, only_robotic = TRUE)
 	if(M.oxyloss > 35)
 		M.setOxyLoss(35, 0)
 	if(M.losebreath >= 4)
@@ -77,7 +77,7 @@
 		M.adjustOxyLoss(-2*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.AdjustKnockdown(-2*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.adjustStaminaLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
-		M.heal_bodypart_damage(1.5,1.5, only_organic = FALSE, only_robotic = TRUE)
+		M.heal_bodypart_damage(3,3, only_organic = FALSE, only_robotic = TRUE)
 		//M.adjustToxLoss(-3*REAGENTS_EFFECT_MULTIPLIER, 0)
 		. = TRUE
 	..()
@@ -113,7 +113,7 @@
 	M.AdjustKnockdown(-2*REAGENTS_EFFECT_MULTIPLIER, 0)
 	M.adjustStaminaLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
 	M.adjustOxyLoss(-1*REAGENTS_EFFECT_MULTIPLIER, 0)
-	M.heal_bodypart_damage(1,1, only_organic = FALSE, only_robotic = TRUE)
+	M.heal_bodypart_damage(2,2, only_organic = FALSE, only_robotic = TRUE)
 	..()
 
 // ---------------------------
@@ -171,7 +171,7 @@
 		M.AdjustKnockdown(-2*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.adjustStaminaLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
 		M.adjustToxLoss(-3*REAGENTS_EFFECT_MULTIPLIER, 0)//Same vars as stimpaks, but reagent effect multiplier <?>
-		M.heal_bodypart_damage(2,2, only_organic = FALSE, only_robotic = TRUE)
+		M.heal_bodypart_damage(4,4, only_organic = FALSE, only_robotic = TRUE)
 	if(M.oxyloss > 35)
 		M.setOxyLoss(35, 0)
 	if(M.losebreath >= 4)
@@ -189,7 +189,7 @@
 		M.AdjustStun(-5*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.AdjustKnockdown(-5*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.adjustStaminaLoss(-3*REAGENTS_EFFECT_MULTIPLIER)
-		M.heal_bodypart_damage(3,3, only_organic = FALSE, only_robotic = TRUE)
+		M.heal_bodypart_damage(6,6, only_organic = FALSE, only_robotic = TRUE)
 		. = TRUE
 	..()
 

--- a/code/modules/fallout/reagents/medicines.dm
+++ b/code/modules/fallout/reagents/medicines.dm
@@ -12,8 +12,11 @@
 	addiction_threshold = 25
 	value = REAGENT_VALUE_RARE
 	ghoulfriendly = TRUE
+	var/clot_rate = 0.25
+	/// If we have multiple bleeding wounds, we count the number of bleeding wounds, then multiply the clot rate by this^(n) before applying it to each cut, so more cuts = less clotting per cut (though still more total clotting)
+	var/clot_coeff_per_wound = 0.9
 
-/datum/reagent/medicine/stimpak/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
+/datum/reagent/medicine/stimpak/reaction_mob(mob/living/carbon/M, method=TOUCH, reac_volume, show_message = 1)
 	if(iscarbon(M) && M.stat != DEAD)
 		if(method in list(INGEST, VAPOR))
 			M.adjustToxLoss(3.75*reac_volume*REAGENTS_EFFECT_MULTIPLIER) //increased from 0.5*reac_volume, which was amusingly low since stimpak heals toxins. now a pill at safe max crits and then heals back up to low health within a few seconds
@@ -21,7 +24,7 @@
 				to_chat(M, "<span class='warning'>You don't feel so good...</span>")
 	..()
 
-/datum/reagent/medicine/stimpak/on_mob_add(mob/living/M)
+/datum/reagent/medicine/stimpak/on_mob_add(mob/living/carbon/M)
 	. = ..()
 	if(M.mind)
 		var/datum/job/job = SSjob.GetJob(M.mind.assigned_role)
@@ -35,16 +38,27 @@
 		var/datum/wound/W = thing
 		var/obj/item/bodypart/wounded_part = W.limb
 		if(wounded_part)
-			wounded_part.heal_damage(10, 10)//Does this even work? AAAAAAAAAAAAAAAAA Original .heal_damage(125, 125)
+			wounded_part.heal_damage(2, 2)//For future cooders, heal_damage does not heal wounds. It heals the limb itself (hence why it uses w.limb)
 	..()
+//THIS CHUNK OF CODE HANDLES STIMPACKS CLOTTING WOUNDS!! THE ABOVE CODE MAKES IT HEAL LIMBS FASTER//
+	var/effective_clot_rate = clot_rate
+	for(var/i in M.all_wounds)
+		var/datum/wound/iter_wound = i
+		if(iter_wound.blood_flow)
+			effective_clot_rate *= clot_coeff_per_wound
+	for(var/i in M.all_wounds)
+		var/datum/wound/iter_wound = i
+		iter_wound.blood_flow = max(0, iter_wound.blood_flow - effective_clot_rate)
+
 	if(M.health < 0)					//Functions as epinephrine.
-		M.adjustToxLoss(-3*REAGENTS_EFFECT_MULTIPLIER, 0)
+//		M.adjustToxLoss(-3*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.adjustBruteLoss(-3*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.adjustFireLoss(-2*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.AdjustStun(-2*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.AdjustKnockdown(-2*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.adjustOxyLoss(-5*REAGENTS_EFFECT_MULTIPLIER,	0)
 		M.adjustStaminaLoss(-2*REAGENTS_EFFECT_MULTIPLIER)//This will probably be horribly unbalanced because of multipliers, but we will see.
+		M.heal_bodypart_damage(1.5,1.5, only_organic = FALSE, only_robotic = TRUE)
 	if(M.oxyloss > 35)
 		M.setOxyLoss(35, 0)
 	if(M.losebreath >= 4)
@@ -63,11 +77,12 @@
 		M.adjustOxyLoss(-2*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.AdjustKnockdown(-2*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.adjustStaminaLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
-		M.adjustToxLoss(-3*REAGENTS_EFFECT_MULTIPLIER, 0)
+		M.heal_bodypart_damage(1.5,1.5, only_organic = FALSE, only_robotic = TRUE)
+		//M.adjustToxLoss(-3*REAGENTS_EFFECT_MULTIPLIER, 0)
 		. = TRUE
 	..()
 
-/datum/reagent/medicine/stimpak/overdose_process(mob/living/M)
+/datum/reagent/medicine/stimpak/overdose_process(mob/living/carbon/M)
 	M.adjustToxLoss(5*REAGENTS_EFFECT_MULTIPLIER)
 	M.adjustOxyLoss(7*REAGENTS_EFFECT_MULTIPLIER)
 	M.drowsyness += 2*REAGENTS_EFFECT_MULTIPLIER
@@ -97,6 +112,8 @@
 	M.AdjustStun(-2*REAGENTS_EFFECT_MULTIPLIER, 0)
 	M.AdjustKnockdown(-2*REAGENTS_EFFECT_MULTIPLIER, 0)
 	M.adjustStaminaLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
+	M.adjustOxyLoss(-1*REAGENTS_EFFECT_MULTIPLIER, 0)
+	M.heal_bodypart_damage(1,1, only_organic = FALSE, only_robotic = TRUE)
 	..()
 
 // ---------------------------
@@ -113,8 +130,11 @@
 	addiction_threshold = 16
 	value = REAGENT_VALUE_VERY_RARE
 	ghoulfriendly = TRUE
+	var/clot_rate = 0.50 //Superstims clot WAY faster
+	/// If we have multiple bleeding wounds, we count the number of bleeding wounds, then multiply the clot rate by this^(n) before applying it to each cut, so more cuts = less clotting per cut (though still more total clotting)
+	var/clot_coeff_per_wound = 0.9
 
-/datum/reagent/medicine/super_stimpak/on_mob_add(mob/living/M)
+/datum/reagent/medicine/super_stimpak/on_mob_add(mob/living/carbon/M)
 	. = ..()
 	if(M.mind)
 		var/datum/job/job = SSjob.GetJob(M.mind.assigned_role)
@@ -123,15 +143,35 @@
 				if(FACTION_LEGION)
 					SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "betrayed caesar", /datum/mood_event/betrayed_caesar, name)
 
-/datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/M)
+/datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/carbon/M)
+	for(var/thing in M.all_wounds)
+		var/datum/wound/W = thing
+		var/obj/item/bodypart/wounded_part = W.limb
+		if(wounded_part)
+			wounded_part.heal_damage(3, 3)//Superstims heal you faster
+	..()
+//THIS CHUNK OF CODE HANDLES CLOTTING WOUNDS!! THE ABOVE CODE MAKES IT HEAL LIMBS FASTER//
+	var/effective_clot_rate = clot_rate
+	for(var/i in M.all_wounds)
+		var/datum/wound/iter_wound = i
+		if(iter_wound.blood_flow)
+			effective_clot_rate *= clot_coeff_per_wound
+	for(var/i in M.all_wounds)
+		var/datum/wound/iter_wound = i
+		iter_wound.blood_flow = max(0, iter_wound.blood_flow - effective_clot_rate)
+	if(M.reagents.has_reagent(/datum/reagent/medicine/medx))
+		M.reagents.remove_reagent(/datum/reagent/medicine/medx, 15) //Removes 15u of Med-X if processing Superstims.
+		to_chat(M, "<span class='warning'>The Med-X And Superstim Fluid in your blood reacts violently!</span>")
 	if(M.health < 0)					//Functions as epinephrine.
-		M.adjustToxLoss(-3*REAGENTS_EFFECT_MULTIPLIER, 0)
+//		M.adjustToxLoss(-3*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.adjustBruteLoss(-3*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.adjustFireLoss(-2*REAGENTS_EFFECT_MULTIPLIER, 0)
+		M.adjustOxyLoss(-5*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.AdjustStun(-2*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.AdjustKnockdown(-2*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.adjustStaminaLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
 		M.adjustToxLoss(-3*REAGENTS_EFFECT_MULTIPLIER, 0)//Same vars as stimpaks, but reagent effect multiplier <?>
+		M.heal_bodypart_damage(2,2, only_organic = FALSE, only_robotic = TRUE)
 	if(M.oxyloss > 35)
 		M.setOxyLoss(35, 0)
 	if(M.losebreath >= 4)
@@ -149,10 +189,11 @@
 		M.AdjustStun(-5*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.AdjustKnockdown(-5*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.adjustStaminaLoss(-3*REAGENTS_EFFECT_MULTIPLIER)
+		M.heal_bodypart_damage(3,3, only_organic = FALSE, only_robotic = TRUE)
 		. = TRUE
 	..()
 
-/datum/reagent/medicine/super_stimpak/overdose_process(mob/living/M)
+/datum/reagent/medicine/super_stimpak/overdose_process(mob/living/carbon/M)
 	M.adjustToxLoss(10*REAGENTS_EFFECT_MULTIPLIER)
 	M.adjustOxyLoss(10*REAGENTS_EFFECT_MULTIPLIER)
 	..()
@@ -187,7 +228,7 @@
 		. = TRUE
 		..()
 
-/datum/reagent/medicine/longpork_stew/overdose_process(mob/living/M)
+/datum/reagent/medicine/longpork_stew/overdose_process(mob/living/carbon/M)
 	M.adjustToxLoss(2*REAGENTS_EFFECT_MULTIPLIER)
 	..()
 	. = TRUE
@@ -255,7 +296,7 @@
 			M.visible_message("<span class='userdanger'>[M] grabs at their throat and vomits violently onto the ground, screaming as they have a seizure! They need medical attention immediately!</span>")
 			to_chat(M, "<span class='userdanger'>The sky splits in half, rays of golden light piercing down towards you. Mars reaches out of the sky above, the holy aura causing you to fall to your knees. He beckoning you to heaven, and you take his hand. Your whole body begins to seize up as you go in a glorious rapture. </span>")
 
-/datum/reagent/medicine/berserker/overdose_process(mob/living/M)
+/datum/reagent/medicine/berserker/overdose_process(mob/living/carbon/M)
 	M.adjustToxLoss(5*REAGENTS_EFFECT_MULTIPLIER)
 	..()
 	. = TRUE
@@ -269,19 +310,31 @@
 	reagent_state = LIQUID
 	color ="#A9FBFB"
 	taste_description = "bitterness"
-	metabolization_rate = 0.5 * REAGENTS_METABOLISM //in between powder/stimpaks and poultice/superstims?
+	metabolization_rate = 0.21 * REAGENTS_METABOLISM //in between powder/stimpaks and poultice/superstims?
 	overdose_threshold = 31
 	var/heal_factor = -5 //Subtractive multiplier if you do not have the perk.
 	var/heal_factor_perk = -5.5 //Multiplier if you have the right perk.
 	ghoulfriendly = TRUE
+	var/clot_rate = 0.15 //Tribal medicine is like smoking a joint and suddenly healing from fatal wounds. It doesn't work very well.
+	/// If we have multiple bleeding wounds, we count the number of bleeding wounds, then multiply the clot rate by this^(n) before applying it to each cut, so more cuts = less clotting per cut (though still more total clotting)
+	var/clot_coeff_per_wound = 0.9
 
 /datum/reagent/medicine/bitter_drink/on_mob_life(mob/living/carbon/M)
 	for(var/thing in M.all_wounds)
 		var/datum/wound/W = thing
 		var/obj/item/bodypart/wounded_part = W.limb
 		if(wounded_part)
-			wounded_part.heal_damage(10, 10)//Does this even work? AAAAAAAAAAAAAAAAA Original .heal_damage(125, 125)
+			wounded_part.heal_damage(1, 1)//Tribal meds are way less efficient at this.
 	..()
+//THIS CHUNK OF CODE HANDLES CLOTTING WOUNDS!! THE ABOVE CODE MAKES IT HEAL LIMBS FASTER//
+	var/effective_clot_rate = clot_rate
+	for(var/i in M.all_wounds)
+		var/datum/wound/iter_wound = i
+		if(iter_wound.blood_flow)
+			effective_clot_rate *= clot_coeff_per_wound
+	for(var/i in M.all_wounds)
+		var/datum/wound/iter_wound = i
+		iter_wound.blood_flow = max(0, iter_wound.blood_flow - effective_clot_rate)
 	var/is_tribal = FALSE
 	if(HAS_TRAIT(M, TRAIT_TRIBAL))
 		is_tribal = TRUE
@@ -295,7 +348,7 @@
 		. = TRUE
 	..()
 
-/datum/reagent/medicine/bitter_drink/overdose_process(mob/living/M)
+/datum/reagent/medicine/bitter_drink/overdose_process(mob/living/carbon/M)
 	M.adjustToxLoss(1*REAGENTS_EFFECT_MULTIPLIER)
 	M.adjustOxyLoss(2*REAGENTS_EFFECT_MULTIPLIER)
 	..()
@@ -311,7 +364,7 @@
 	reagent_state = SOLID
 	color = "#A9FBFB"
 	taste_description = "bitterness"
-	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	metabolization_rate = 0.2 * REAGENTS_METABOLISM
 	overdose_threshold = 30
 	var/heal_factor = -2 //Subtractive multiplier if you do not have the perk.
 	var/heal_factor_perk = -2.2 //Multiplier if you have the right perk.
@@ -330,7 +383,7 @@
 	. = TRUE
 	..()
 
-/datum/reagent/medicine/healing_powder/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
+/datum/reagent/medicine/healing_powder/reaction_mob(mob/living/carbon/M, method=TOUCH, reac_volume, show_message = 1)
 	if(iscarbon(M) && M.stat != DEAD)
 		if(method in list(INGEST, VAPOR, INJECT))
 			M.adjustToxLoss(3*reac_volume*REAGENTS_EFFECT_MULTIPLIER) //also increased from 0.5, reduced from 6
@@ -338,7 +391,7 @@
 				to_chat(M, "<span class='warning'>You don't feel so good...</span>")
 	..()
 
-/datum/reagent/medicine/healing_powder/overdose_process(mob/living/M)
+/datum/reagent/medicine/healing_powder/overdose_process(mob/living/carbon/M)
 	M.adjustToxLoss(2*REAGENTS_EFFECT_MULTIPLIER)
 	M.adjustOxyLoss(4*REAGENTS_EFFECT_MULTIPLIER)
 	..()
@@ -352,6 +405,8 @@
 	description = "Restores limb condition and heals rapidly."
 	color = "#C8A5DC"
 	overdose_threshold = 20
+	heal_factor = -2
+	heal_factor_perk = -2.2
 	heal_factor = -3.0
 	heal_factor_perk = -3.5
 
@@ -480,13 +535,13 @@
 		to_chat(M, "<span class='userdanger'>Too much med-x! </span>")
 	..()
 
-/datum/reagent/medicine/medx/addiction_act_stage1(mob/living/M)
+/datum/reagent/medicine/medx/addiction_act_stage1(mob/living/carbon/M)
 	if(prob(33))
 		M.drop_all_held_items()
 		M.Jitter(2)
 	..()
 
-/datum/reagent/medicine/medx/addiction_act_stage2(mob/living/M)
+/datum/reagent/medicine/medx/addiction_act_stage2(mob/living/carbon/M)
 	if(prob(33))
 		M.drop_all_held_items()
 		M.adjustToxLoss(1*REAGENTS_EFFECT_MULTIPLIER)
@@ -495,7 +550,7 @@
 		M.Jitter(3)
 	..()
 
-/datum/reagent/medicine/medx/addiction_act_stage3(mob/living/M)
+/datum/reagent/medicine/medx/addiction_act_stage3(mob/living/carbon/M)
 	if(prob(33))
 		M.drop_all_held_items()
 		M.adjustToxLoss(2*REAGENTS_EFFECT_MULTIPLIER)
@@ -504,7 +559,7 @@
 		M.Jitter(4)
 	..()
 
-/datum/reagent/medicine/medx/addiction_act_stage4(mob/living/M)
+/datum/reagent/medicine/medx/addiction_act_stage4(mob/living/carbon/M)
 	if(prob(33))
 		M.drop_all_held_items()
 		M.adjustToxLoss(3*REAGENTS_EFFECT_MULTIPLIER)
@@ -545,20 +600,20 @@
 	..()
 	. = TRUE
 
-/datum/reagent/medicine/legionmedx/overdose_process(mob/living/M)
+/datum/reagent/medicine/legionmedx/overdose_process(mob/living/carbon/M)
 	if(prob(33))
 		M.drop_all_held_items()
 		M.Dizzy(2)
 		M.Jitter(2)
 	..()
 
-/datum/reagent/medicine/legionmedx/addiction_act_stage1(mob/living/M)
+/datum/reagent/medicine/legionmedx/addiction_act_stage1(mob/living/carbon/M)
 	if(prob(33))
 		M.drop_all_held_items()
 		M.Jitter(2)
 	..()
 
-/datum/reagent/medicine/legionmedx/addiction_act_stage2(mob/living/M)
+/datum/reagent/medicine/legionmedx/addiction_act_stage2(mob/living/carbon/M)
 	if(prob(33))
 		M.drop_all_held_items()
 		M.adjustToxLoss(1*REAGENTS_EFFECT_MULTIPLIER)
@@ -567,7 +622,7 @@
 		M.Jitter(3)
 	..()
 
-/datum/reagent/medicine/legionmedx/addiction_act_stage3(mob/living/M)
+/datum/reagent/medicine/legionmedx/addiction_act_stage3(mob/living/carbon/M)
 	if(prob(33))
 		M.drop_all_held_items()
 		M.adjustToxLoss(2*REAGENTS_EFFECT_MULTIPLIER)
@@ -576,7 +631,7 @@
 		M.Jitter(4)
 	..()
 
-/datum/reagent/medicine/legionmedx/addiction_act_stage4(mob/living/M)
+/datum/reagent/medicine/legionmedx/addiction_act_stage4(mob/living/carbon/M)
 	if(prob(33))
 		M.drop_all_held_items()
 		M.adjustToxLoss(3*REAGENTS_EFFECT_MULTIPLIER)
@@ -627,26 +682,26 @@
 	..()
 	. = TRUE
 
-/datum/reagent/medicine/mentat/overdose_process(mob/living/M)
+/datum/reagent/medicine/mentat/overdose_process(mob/living/carbon/M)
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 15)
 	if(prob(33))
 		M.Dizzy(2)
 		M.Jitter(2)
 	..()
 
-/datum/reagent/medicine/mentat/addiction_act_stage1(mob/living/M)
+/datum/reagent/medicine/mentat/addiction_act_stage1(mob/living/carbon/M)
 	if(prob(33))
 		M.Jitter(2)
 	..()
 
-/datum/reagent/medicine/mentat/addiction_act_stage2(mob/living/M)
+/datum/reagent/medicine/mentat/addiction_act_stage2(mob/living/carbon/M)
 	if(prob(33))
 		. = TRUE
 		M.Dizzy(3)
 		M.Jitter(3)
 	..()
 
-/datum/reagent/medicine/mentat/addiction_act_stage3(mob/living/M)
+/datum/reagent/medicine/mentat/addiction_act_stage3(mob/living/carbon/M)
 	if(prob(33))
 		M.adjustToxLoss(1*REAGENTS_EFFECT_MULTIPLIER)
 //		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2)
@@ -655,7 +710,7 @@
 		M.Jitter(4)
 	..()
 
-/datum/reagent/medicine/mentat/addiction_act_stage4(mob/living/M)
+/datum/reagent/medicine/mentat/addiction_act_stage4(mob/living/carbon/M)
 	if(prob(33))
 		M.drop_all_held_items()
 		M.adjustToxLoss(2*REAGENTS_EFFECT_MULTIPLIER)
@@ -711,7 +766,7 @@
 	M.adjustFireLoss(-0.75*REAGENTS_EFFECT_MULTIPLIER, 0)
 	..()
 
-/datum/reagent/medicine/gaia/overdose_start(mob/living/M)
+/datum/reagent/medicine/gaia/overdose_start(mob/living/carbon/M)
 	metabolization_rate = 15 * REAGENTS_METABOLISM
 	..()
 
@@ -727,43 +782,55 @@
 	overdose_threshold = 16//No real downsides with use, aside from popping it twice quickly.
 	addiction_threshold = 14//No real downsides with use, aside from popping it twice quickly.
 	self_consuming = TRUE//So you can process without a liver. For future disembowelment reworks.
+	var/clot_rate = 0.2 //Hydra is still natural medicine.
+	/// If we have multiple bleeding wounds, we count the number of bleeding wounds, then multiply the clot rate by this^(n) before applying it to each cut, so more cuts = less clotting per cut (though still more total clotting)
+	var/clot_coeff_per_wound = 0.9
 
 /datum/reagent/medicine/hydra/on_mob_life(mob/living/carbon/M)
 	for(var/thing in M.all_wounds)
 		var/datum/wound/W = thing
 		var/obj/item/bodypart/wounded_part = W.limb
 		if(wounded_part)
-			wounded_part.heal_damage(10, 10)//Does this even work? AAAAAAAAAAAAAAAAA Original .heal_damage(125, 125)
+			wounded_part.heal_damage(1.5, 1.5)//Hydra is meant to be decent at this
 	..()
+//THIS CHUNK OF CODE HANDLES CLOTTING WOUNDS!! THE ABOVE CODE MAKES IT HEAL LIMBS FASTER//
+	var/effective_clot_rate = clot_rate
+	for(var/i in M.all_wounds)
+		var/datum/wound/iter_wound = i
+		if(iter_wound.blood_flow)
+			effective_clot_rate *= clot_coeff_per_wound
+	for(var/i in M.all_wounds)
+		var/datum/wound/iter_wound = i
+		iter_wound.blood_flow = max(0, iter_wound.blood_flow - effective_clot_rate)
 
-/datum/reagent/medicine/hydra/overdose_process(mob/living/M)
+/datum/reagent/medicine/hydra/overdose_process(mob/living/carbon/M)
 	if(prob(33))
 		M.drop_all_held_items()
 		M.Dizzy(2)
 		M.Jitter(2)
 	..()
 
-/datum/reagent/medicine/hydra/addiction_act_stage1(mob/living/M)
+/datum/reagent/medicine/hydra/addiction_act_stage1(mob/living/carbon/M)
 	if(prob(33))
 		M.drop_all_held_items()
 		M.Jitter(2)
 	..()
 
-/datum/reagent/medicine/hydra/addiction_act_stage2(mob/living/M)
+/datum/reagent/medicine/hydra/addiction_act_stage2(mob/living/carbon/M)
 	if(prob(33))
 		M.drop_all_held_items()
 		M.Dizzy(3)
 		M.Jitter(3)
 	..()
 
-/datum/reagent/medicine/hydra/addiction_act_stage3(mob/living/M)
+/datum/reagent/medicine/hydra/addiction_act_stage3(mob/living/carbon/M)
 	if(prob(33))
 		M.drop_all_held_items()
 		M.Dizzy(4)
 		M.Jitter(4)
 	..()
 
-/datum/reagent/medicine/hydra/addiction_act_stage4(mob/living/M)
+/datum/reagent/medicine/hydra/addiction_act_stage4(mob/living/carbon/M)
 	if(prob(33))
 		M.drop_all_held_items()
 		M.Dizzy(5)

--- a/code/modules/fallout/reagents/medicines.dm
+++ b/code/modules/fallout/reagents/medicines.dm
@@ -58,7 +58,7 @@
 		M.AdjustKnockdown(-2*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.adjustOxyLoss(-5*REAGENTS_EFFECT_MULTIPLIER,	0)
 		M.adjustStaminaLoss(-2*REAGENTS_EFFECT_MULTIPLIER)//This will probably be horribly unbalanced because of multipliers, but we will see.
-		M.heal_bodypart_damage(3,3, only_organic = FALSE, only_robotic = TRUE)
+		M.heal_bodypart_damage(1.5,1.5, only_organic = FALSE, only_robotic = TRUE)
 	if(M.oxyloss > 35)
 		M.setOxyLoss(35, 0)
 	if(M.losebreath >= 4)
@@ -77,7 +77,7 @@
 		M.adjustOxyLoss(-2*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.AdjustKnockdown(-2*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.adjustStaminaLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
-		M.heal_bodypart_damage(3,3, only_organic = FALSE, only_robotic = TRUE)
+		M.heal_bodypart_damage(1.5,1.5, only_organic = FALSE, only_robotic = TRUE)
 		//M.adjustToxLoss(-3*REAGENTS_EFFECT_MULTIPLIER, 0)
 		. = TRUE
 	..()
@@ -113,7 +113,7 @@
 	M.AdjustKnockdown(-2*REAGENTS_EFFECT_MULTIPLIER, 0)
 	M.adjustStaminaLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
 	M.adjustOxyLoss(-1*REAGENTS_EFFECT_MULTIPLIER, 0)
-	M.heal_bodypart_damage(2,2, only_organic = FALSE, only_robotic = TRUE)
+	M.heal_bodypart_damage(1,1, only_organic = FALSE, only_robotic = TRUE)
 	..()
 
 // ---------------------------
@@ -171,7 +171,7 @@
 		M.AdjustKnockdown(-2*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.adjustStaminaLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
 		M.adjustToxLoss(-3*REAGENTS_EFFECT_MULTIPLIER, 0)//Same vars as stimpaks, but reagent effect multiplier <?>
-		M.heal_bodypart_damage(4,4, only_organic = FALSE, only_robotic = TRUE)
+		M.heal_bodypart_damage(2,2, only_organic = FALSE, only_robotic = TRUE)
 	if(M.oxyloss > 35)
 		M.setOxyLoss(35, 0)
 	if(M.losebreath >= 4)
@@ -189,7 +189,7 @@
 		M.AdjustStun(-5*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.AdjustKnockdown(-5*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.adjustStaminaLoss(-3*REAGENTS_EFFECT_MULTIPLIER)
-		M.heal_bodypart_damage(6,6, only_organic = FALSE, only_robotic = TRUE)
+		M.heal_bodypart_damage(3,3, only_organic = FALSE, only_robotic = TRUE)
 		. = TRUE
 	..()
 

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -40,7 +40,7 @@
 
 /datum/emote/living/subtle/proc/check_invalid(mob/user, input)
 	if(stop_bad_mime.Find(input, 1, 1))
-		to_chat(user, "<span class='danger'>Invalid emote.</span>")
+		to_chat(user, span_danger("Invalid emote."))
 		return TRUE
 	return FALSE
 
@@ -65,26 +65,29 @@
 	if(!can_run_emote(user))
 		return FALSE
 
-	user.log_message(message, LOG_EMOTE)
-	message = span_subtle("<b>[user]</b> " + "<i>[user.say_emphasis(message)]</i>")
+	user.log_message(message, subtler ? LOG_SUBTLER : LOG_SUBTLE)
+	var/msg_check = user.say_narrate_replace(message, user)
+	if(msg_check)
+		message = span_subtle("<i>[msg_check]</i>")
+	else
+		message = span_subtle("<b>[user]</b> " + "<i>[user.say_emphasis(message)]</i>")
 
-	var/list/ghosties = list()
+	var/list/non_admin_ghosts
 	// Exclude ghosts from the initial message if its a subtler, lets be *discrete*
 	if(subtler)
-		for(var/mob/ghost in GLOB.dead_mob_list)
-			if(ghost.client && !check_rights_for(ghost.client, R_ADMIN))
-				continue
-			ghosties |= ghost
-
+		non_admin_ghosts = GLOB.dead_mob_list.Copy()
+		for(var/mob/ghostie in GLOB.dead_mob_list)
+			if(ghostie.client && check_rights_for(ghostie.client, R_ADMIN))
+				non_admin_ghosts.Remove(ghostie)
 	// Everyone in range can see it
 	user.visible_message(
 		message = message,
 		blind_message = message,
 		self_message = message,
 		vision_distance = 1,
-		ignored_mobs = ghosties)
+		ignored_mobs = non_admin_ghosts)
 
-	//broadcast to ghosts, if they have a client, are dead, arent in the lobby, allow ghostsight,
+	//broadcast to ghosts, if they have a client, are dead, arent in the lobby, allow ghostsight, and, if subtler, are admemes
 	user.emote_for_ghost_sight(message, subtler)
 
 


### PR DESCRIPTION
## About The Pull Request
Ports part of an afterglow PR editing the mob/say_vr file so subtler anti-ghost is actually anti-ghost.

## Why It's Good For The Game
Makes anti-ghost work as originally intended and prevents people tabbing through who's alive from being hit by flashbangs while also making things more private. Does as says on the tin.

## Changelog
fix: Subtler Anti-Ghost actually Anti-Ghosts (holy shit)

https://github.com/JasmineRickards/Wasteland-After-Dark/assets/76122712/ecf6a0f4-b1e6-4451-82f0-ac598d33f1d6