### PR TITLE
Makes the Bitter Drink crafting recipe cost correct

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -59,14 +59,14 @@
 /datum/crafting_recipe/bitterdrink
 	name = "Bottle bitterdrink"
 	result = /obj/item/reagent_containers/pill/patch/bitterdrink
-	reqs = list(/datum/reagent/medicine/bitter_drink = 30)
+	reqs = list(/datum/reagent/medicine/bitter_drink = 15)
 	time = 20
 	category = CAT_MEDICAL
 
 /datum/crafting_recipe/bitterdrink5
 	name = "Batch of bitterdrink (x5)"
 	result = /obj/item/storage/box/medicine/bitterdrink5
-	reqs = list(/datum/reagent/medicine/bitter_drink = 150)
+	reqs = list(/datum/reagent/medicine/bitter_drink = 75)
 	time = 30
 	category = CAT_MEDICAL
 


### PR DESCRIPTION
1 crafted bottle of Bitter Drink has 15 units of the chemical in it, but takes 30 units to make. This makes the crafting cost the same as what's in the product.