### PR TITLE
Gives the Enclave Lieutenant the ability to fly the Vertibird

### DIFF
--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -131,6 +131,7 @@
 	ADD_TRAIT(H, TRAIT_LIFEGIVER, src)
 	ADD_TRAIT(H, TRAIT_RESEARCHER, src)
 	ADD_TRAIT(H, TRAIT_ENCLAVE_CODES, src)
+    ADD_TRAIT(H, TRAIT_PILOT, src)
 	if(H.mind)
 		var/obj/effect/proc_holder/spell/terrifying_presence/S = new /obj/effect/proc_holder/spell/terrifying_presence
 		H.mind.AddSpell(S)


### PR DESCRIPTION
Useful in the case where the Lieutenant wants the Enclave to go out and do some field work for the week, but no Pilot is present to pilot the Vertibird.